### PR TITLE
Test and fix the notebook tester

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -26,5 +26,5 @@ jobs:
     name: 'Windows'
     pool:
       vmImage: 'vs2017-win2016'
-    env:
-      TMPDIR: $(Agent.TempDirectory)
+  variables:
+    TMPDIR: $(Agent.TempDirectory)

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -14,6 +14,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     packages: true
+    also_forked: true
 
 - template: template.yml
   parameters:

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -26,5 +26,3 @@ jobs:
     name: 'Windows'
     pool:
       vmImage: 'vs2017-win2016'
-  variables:
-    TMPDIR: $(Agent.TempDirectory)

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -14,7 +14,6 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     packages: true
-    also_forked: true
 
 - template: template.yml
   parameters:
@@ -27,3 +26,4 @@ jobs:
     name: 'Windows'
     pool:
       vmImage: 'vs2017-win2016'
+    also_forked: false

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -26,3 +26,5 @@ jobs:
     name: 'Windows'
     pool:
       vmImage: 'vs2017-win2016'
+    env:
+      TMPDIR: $(Agent.TempDirectory)

--- a/.azure/template.yml
+++ b/.azure/template.yml
@@ -2,7 +2,7 @@ parameters:
   name: ''
   pool: ''
   packages: false
-  also_forked: false
+  also_forked: true
 
 jobs:
 - job: ${{ parameters.name }}

--- a/.azure/template.yml
+++ b/.azure/template.yml
@@ -2,6 +2,7 @@ parameters:
   name: ''
   pool: ''
   packages: false
+  also_forked: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -46,6 +47,13 @@ jobs:
   - script:
       make tests
     displayName: 'Test'
+
+  - ${{ if eq(parameters.also_forked, 'true') }}:
+
+    - script: |
+        make testpy-forked
+      displayName: 'pytest --forked'
+
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/.azure/template.yml
+++ b/.azure/template.yml
@@ -44,16 +44,15 @@ jobs:
       make lint
     displayName: 'Lint'
 
-  - script:
-      make tests
-    displayName: 'Test'
-
   - ${{ if eq(parameters.also_forked, 'true') }}:
 
-    - script: |
+    - script:
         make testpy-forked
       displayName: 'pytest --forked'
 
+  - script:
+      make tests
+    displayName: 'Test'
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ testjs: ## Clean and Make js tests
 testpy: ## Clean and Make unit tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests
 
-testpyforked: ## Python unit tests --forked (not windows!)
+testpy-forked: ## Python unit tests --forked (not windows!)
 	${PYTHON} -m pytest -v --forked nbcelltests/tests
 
 tests: lint ## run the tests

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ testjs: ## Clean and Make js tests
 testpy: ## Clean and Make unit tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests
 
+testpyforked: ## Python unit tests --forked (not windows!)
+	${PYTHON} -m pytest -v --forked nbcelltests/tests
+
 tests: lint ## run the tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests --junitxml=python_junit.xml --cov-report=xml --cov-branch
 	yarn test

--- a/nbcelltests/tests/_cell_error.ipynb
+++ b/nbcelltests/tests/_cell_error.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "tests": [
+     "print(\"cell 0 test\")\n",
+     "%cell\n",
+     "raise TypeError(\"should never get here as the cell source errors\")"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 0 source\")\n",
+    "raise ValueError(\"My code does not even run\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_cell_error.ipynb
+++ b/nbcelltests/tests/_cell_error.ipynb
@@ -2,17 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "tests": [
-     "print(\"cell 0 test\")\n",
      "%cell\n",
      "raise TypeError(\"should never get here as the cell source errors\")"
     ]
    },
    "outputs": [],
    "source": [
-    "print(\"cell 0 source\")\n",
     "raise ValueError(\"My code does not even run\")"
    ]
   }

--- a/nbcelltests/tests/_cumulative_run.ipynb
+++ b/nbcelltests/tests/_cumulative_run.ipynb
@@ -5,12 +5,11 @@
    "execution_count": 0,
    "metadata": {
     "tests": [
-     "print(\"cell 0 test\")"
+     "pass"
     ]
    },
    "outputs": [],
    "source": [
-    "print(\"cell 0 source\")\n",
     "x = 0"
    ]
   },
@@ -19,14 +18,15 @@
    "execution_count": 1,
    "metadata": {
     "tests": [
-     "print(\"cell 1 test\")\n",
      "%cell"
     ]
    },
    "outputs": [],
    "source": [
-    "print(\"cell 1 source\")\n",
-    "x = 0"
+    "try:\n",
+    "    x\n",
+    "except NameError:\n",
+    "    x = 0"
    ]
   },  
   {
@@ -34,79 +34,39 @@
    "execution_count": 2,
    "metadata": {
     "tests": [
-     "print(\"cell 2 test\")\n",
      "%cell"
     ]
    },
    "outputs": [],
    "source": [
-    "print(\"cell 2 source\")\n",
     "x += 1"
    ]
-  },  
+  },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
     "tests": [
-     "print(\"cell 3 test\")\n",
+     "%cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x += 1"
+   ]
+  },    
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tests": [
      "%cell\n",
      "x += 1"
     ]
    },
    "outputs": [],
    "source": [
-    "print(\"cell 3 source\")\n",
     "pass"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "tests": [
-     "print(\"cell 4 test\")\n",
-     "%cell\n",
-     "raise TypeError(\"should never get here as the cell source errors\")"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "print(\"cell 4 source\")\n",
-    "raise ValueError(\"My code does not even run\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "tests": [
-     "print(\"cell 5 test\")\n",
-     "try:\n",
-     "    %cell\n",
-     "except:\n",
-     "    pass\n",
-     "raise ValueError(\"My test does not even run\")"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "print(\"cell 5 source\")\n",
-    "ValueError(\"Deliberately not raising\")"
-   ]
-  },  
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "tests": [
-     "# Use %cell to execute the cell\n",
-     "%cell\n"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "x=4; assert x == 2"
    ]
   }
  ],

--- a/nbcelltests/tests/_cumulative_run.ipynb
+++ b/nbcelltests/tests/_cumulative_run.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "tests": [
      "pass"
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "tests": [
      "%cell"
@@ -31,7 +31,7 @@
   },  
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "tests": [
      "%cell"
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "tests": [
      "%cell"
@@ -57,7 +57,7 @@
   },    
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "tests": [
      "%cell\n",

--- a/nbcelltests/tests/_cumulative_run.ipynb
+++ b/nbcelltests/tests/_cumulative_run.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "tests": [
+     "print(\"cell 0 test\")"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 0 source\")\n",
+    "x = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tests": [
+     "print(\"cell 1 test\")\n",
+     "%cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 1 source\")\n",
+    "x = 0"
+   ]
+  },  
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tests": [
+     "print(\"cell 2 test\")\n",
+     "%cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 2 source\")\n",
+    "x += 1"
+   ]
+  },  
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tests": [
+     "print(\"cell 3 test\")\n",
+     "%cell\n",
+     "x += 1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 3 source\")\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tests": [
+     "print(\"cell 4 test\")\n",
+     "%cell\n",
+     "raise TypeError(\"should never get here as the cell source errors\")"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 4 source\")\n",
+    "raise ValueError(\"My code does not even run\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tests": [
+     "print(\"cell 5 test\")\n",
+     "try:\n",
+     "    %cell\n",
+     "except:\n",
+     "    pass\n",
+     "raise ValueError(\"My test does not even run\")"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(\"cell 5 source\")\n",
+    "ValueError(\"Deliberately not raising\")"
+   ]
+  },  
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tests": [
+     "# Use %cell to execute the cell\n",
+     "%cell\n"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x=4; assert x == 2"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_test_error.ipynb
+++ b/nbcelltests/tests/_test_error.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "tests": [
      "try:\n",
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "tests": [
      "try:\n",

--- a/nbcelltests/tests/_test_error.ipynb
+++ b/nbcelltests/tests/_test_error.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "tests": [
+     "try:\n",
+     "    %cell\n",
+     "except:\n",
+     "    pass"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "raise ValueError(\"My bad code that I will pretend to test\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tests": [
+     "try:\n",
+     "    %cell\n",
+     "except:\n",
+     "    pass\n",
+     "raise ValueError(\"My test is bad too\")"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "raise ValueError(\"More bad code that I will pretend to test\")"
+   ]
+  }  
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_test_fail.ipynb
+++ b/nbcelltests/tests/_test_fail.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "tests": [
      "%cell\n",

--- a/nbcelltests/tests/_test_fail.ipynb
+++ b/nbcelltests/tests/_test_fail.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "assert x == -1, \"x should have been -1 but was %s\"%x"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  }  
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -75,9 +75,6 @@ class TestTestCumulativeRun(_TestTest):
     NBNAME = CUMULATIVE_RUN
 
     def test_state(self):
-
-        # TODO: and split up, depending whether testing fresh kernel per test or not
-
         t = self.generated_tests.TestNotebook()
         t.setUpClass()
 

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -68,21 +68,29 @@ class TestCumulativeRun(_TestCellTests):
     NBNAME = CUMULATIVE_RUN
 
     def test_state(self):
-        """
-                    cell    test   state
-        0:           -       -       -
+        """In the expected case, the five cells of the notebook should work
+        out as follows:
 
-        1: either   x=0      -      x=0   (expected)
-               or    -       -      x>0   (bad; x was previously defined in kernel)
+             cell    test   state
+        1:    -       -       -
+        2:   x=0      -      x=0
+        3:   x+=1     -      x=1
+        4:   x+=1     -      x=2
+        5:    -      x+=1    x=3
 
-        2: either   x+=1     -      x=1   (expected)
-               or   x+=1     -      x>1   (bad)
+        However, these tests originally detected repeated execution of
+        cells in the same kernel. Cell 2 actually only sets x to 0 if
+        x is not already defined; if x is already defined, cell 2 does
+        not change x's value. If for some reason each test results in
+        multiple executions of the cells, the results will look like
+        this:
 
-        3: either   x+=1     -      x=2   (expected)
-               or   x+=1     -      x>2   (bad)
-
-        4: either    -      x+=1    x=3   (expected)
-               or    -      x+=1    x>3   (bad)
+             cell    test   state
+        1:    -       -       -
+        2:    -       -      x>0   (bad; x was previously defined in kernel)
+        3:   x+=1     -      x>1   (bad)
+        4:   x+=1     -      x>2   (bad)
+        5:    -      x+=1    x>3   (bad)
         """
         t = self.generated_tests.TestNotebook()
         t.setUpClass()

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -71,16 +71,16 @@ class TestCumulativeRun(_TestCellTests):
         """
                     cell    test   state
         0:           -       -       -
-        
+
         1: either   x=0      -      x=0   (expected)
                or    -       -      x>0   (bad; x was previously defined in kernel)
-        
+
         2: either   x+=1     -      x=1   (expected)
                or   x+=1     -      x>1   (bad)
-        
+
         3: either   x+=1     -      x=2   (expected)
                or   x+=1     -      x>2   (bad)
-        
+
         4: either    -      x+=1    x=3   (expected)
                or    -      x+=1    x>3   (bad)
         """

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -69,13 +69,27 @@ class TestCumulativeRun(_TestCellTests):
     NBNAME = CUMULATIVE_RUN
 
     def test_state(self):
+        """
+                    cell    test   state
+        0:           -       -       -
+        
+        1: either   x=0      -      x=0   (expected)
+               or    -       -      x>0   (bad; x was previously defined in kernel)
+        
+        2: either   x+=1     -      x=1   (expected)
+               or   x+=1     -      x>1   (bad)
+        
+        3: either   x+=1     -      x=2   (expected)
+               or   x+=1     -      x>2   (bad)
+        
+        4: either    -      x+=1    x=3   (expected)
+               or    -      x+=1    x>3   (bad)
+        """
         t = self.generated_tests.TestNotebook()
         t.setUpClass()
 
         # check cell did not run
         # (no %cell in test)
-        #    cell  test  state
-        # 0:  -     -      -
         t.setUp()
         _assert_x_undefined(t)
         t.test_cell_0()
@@ -86,9 +100,6 @@ class TestCumulativeRun(_TestCellTests):
 
         # check cell ran
         # (%cell in test)
-        #    cell  test  state
-        # 0:  -     -      -
-        # 1: x=0    -     x=0
         if FORKED:
             t.setUpClass()
         t.setUp()
@@ -101,10 +112,6 @@ class TestCumulativeRun(_TestCellTests):
             t.tearDownClass()
 
         # check cumulative cells ran
-        #    cell  test  state
-        # 0:  -     -      -
-        # 1: x=0    -     x=0
-        # 2: x+=1   -     x=1
         if FORKED:
             t.setUpClass()
         t.setUp()
@@ -117,11 +124,6 @@ class TestCumulativeRun(_TestCellTests):
             t.tearDownClass()
 
         # check cumulative cells ran (but not multiple times!)
-        #    cell  test  state
-        # 0:  -     -      -
-        # 1: x=0    -     x=0
-        # 2: x+=1   -     x=1
-        # 3: x+=1   -     x=2
         if FORKED:
             t.setUpClass()
         t.setUp()
@@ -134,12 +136,6 @@ class TestCumulativeRun(_TestCellTests):
             t.tearDownClass()
 
         # check test affects state
-        #    cell  test  state
-        # 0:  -     -      -
-        # 1: x=0    -     x=0
-        # 2: x+=1   -     x=1
-        # 3: x+=1   -     x=2
-        # 4:  -    x+=1   x=3
         if FORKED:
             t.setUpClass()
         t.setUp()

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -22,7 +22,6 @@ TEST_FAIL = os.path.join(os.path.dirname(__file__), '_test_fail.ipynb')
 # Hack. We want to test expected behavior in distributed situation,
 # which we are doing via pytest --forked.
 FORKED = '--forked' in sys.argv
-assert not FORKED
 
 
 def _assert_x_undefined(t):

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -5,9 +5,174 @@
 # This file is part of the nbcelltests library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
-# for Coverage
+import tempfile
+import os
+import unittest
+
+from nbcelltests.test import run
+
+# TODO: we should generate the notebooks rather than having them as files
+# (same for lint ones)
+CUMULATIVE_RUN = os.path.join(os.path.dirname(__file__), '_cumulative_run.ipynb')
+CELL_ERROR = os.path.join(os.path.dirname(__file__), '_cell_error.ipynb')
+TEST_ERROR = os.path.join(os.path.dirname(__file__), '_test_error.ipynb')
+TEST_FAIL = os.path.join(os.path.dirname(__file__), '_test_fail.ipynb')
+
+# TODO: each generated test includes all the previous cells+tests.
+# I.e. each test could be run in independent (fresh) kernel (allows
+# things like distributing tests etc - but at the cost of slow kernel
+# startup per test). Currently the generated tests just create the
+# kernel per notebook not per cell, so test like that.
+FRESH_KERNEL_PER_TEST = False
+
+def _check_fresh(t, force_fresh=False):
+    if FRESH_KERNEL_PER_TEST or force_fresh:
+        t.run_test("""
+        try:
+            x
+        except NameError:
+            pass
+        else:
+            raise Exception('x was already defined - kernel is not fresh')
+        """)
+
+# TODO: This test file's manual use of unittest is brittle, but just
+# want to get started asserting what the current behavior is before
+# cleaning up/documenting.
 
 
-class TestTests:
-    def test_run(self):
-        pass
+def _import_from_path(pypath,f):
+    # TODO consider py version compat
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(pypath, f)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _TestTest(unittest.TestCase):
+    # abstract :)
+
+    @classmethod
+    def setUpClass(cls):
+        with tempfile.NamedTemporaryFile(suffix='.py') as f:
+            cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s"%(__name__,cls.__name__), run(cls.NBNAME, filename=f.name))
+        
+
+class TestTestCumulativeRun(_TestTest):
+
+    NBNAME = CUMULATIVE_RUN
+    
+    def test_state(self):
+        # TODO: and split up, depending whether testing fresh kernel per test or not
+        
+        t = self.generated_tests.TestNotebook()
+        t.setup_class()
+
+        ######### check cell did not run
+        _check_fresh(t)
+        t.test_cell_0()
+        _check_fresh(t, force_fresh=True)
+
+
+        ######### check cell ran
+        _check_fresh(t)
+        t.test_cell_1()
+        t.run_test("""
+        assert x == 0, x
+        """)
+        
+        ######### cumulative cells ran
+        _check_fresh(t)
+        t.test_cell_2()
+        t.run_test("""
+        assert x == 1, x
+        """)
+        
+        ######### check test affects state
+        _check_fresh(t)
+        t.test_cell_3()
+        t.run_test("""
+        assert x == 2, x
+        """)
+
+
+        t.teardown_class()
+
+
+class TestTestCellException(_TestTest):
+
+    NBNAME = CELL_ERROR
+    
+    def test_cell_exception(self):
+        t = self.generated_tests.TestNotebook()
+        t.setup_class()
+
+
+        ######### cell errors
+        _check_fresh(t)
+        
+        try:
+            t.test_cell_0()
+        except Exception as e:
+            assert e.args[0].startswith("Cell execution caused an exception")
+            assert e.args[0].endswith("My code does not even run")
+        else:
+            raise Exception("Cell should have errored out")
+
+        
+        t.teardown_class()
+
+
+class TestTestTestException(_TestTest):
+
+    NBNAME = TEST_ERROR
+    
+    def test_exception_in_test(self):
+        t = self.generated_tests.TestNotebook()
+        t.setup_class()
+
+
+        ######### caught cell error
+        _check_fresh(t)
+        t.test_cell_0()
+        
+        ######### test errors
+        _check_fresh(t)
+        try:
+            t.test_cell_1()
+        except Exception as e:
+            assert e.args[0].startswith("Cell execution caused an exception")
+            assert e.args[0].endswith("My test is bad too")
+        else:
+            raise Exception("Test should have failed")
+                
+
+        
+        t.teardown_class()
+
+
+class TestTestTestFail(_TestTest):
+
+    NBNAME = TEST_FAIL
+    
+    def test_expected_fail(self):
+        t = self.generated_tests.TestNotebook()
+        t.setup_class()
+
+
+        ######### caught cell error
+        _check_fresh(t)
+        try:
+            t.test_cell_0()        
+        except Exception as e:
+            assert e.args[0].startswith("Cell execution caused an exception")
+            assert e.args[0].endswith("x should have been -1 but was 1")
+        else:
+            raise Exception("Test should have failed")
+                
+
+        
+        t.teardown_class()
+
+

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -20,10 +20,10 @@ TEST_ERROR = os.path.join(os.path.dirname(__file__), '_test_error.ipynb')
 TEST_FAIL = os.path.join(os.path.dirname(__file__), '_test_fail.ipynb')
 
 # Each generated test includes all the previous cells+tests.
-# I.e. each test could be run in independent (fresh) kernel (allows
+# I.e. each test can be run in independent (fresh) kernel (allows
 # things like distributing tests etc - but at the cost of slow kernel
-# startup per test). Currently the generated tests just create the
-# kernel per notebook not per cell, so test like that.
+# startup per test). Currently the generated tests create a new kernel
+# per cell, so test like that.
 EXPECT_FRESH_KERNEL_PER_TEST = True
 
 # Hack. We want to test expected behavior in distributed situation,
@@ -42,13 +42,10 @@ def _check_fresh(t, override_fresh=False):
             raise Exception('x was already defined - kernel is not fresh')
         """)
 
-# TODO: This test file's manual use of unittest is brittle, but just
-# want to get started asserting what the current behavior is before
-# cleaning up/documenting.
+# TODO: This test file's manual use of unittest is brittle
 
 
 def _import_from_path(pypath, f):
-    # TODO consider py version compat
     import importlib.util
     spec = importlib.util.spec_from_file_location(pypath, f)
     mod = importlib.util.module_from_spec(spec)
@@ -100,7 +97,7 @@ class TestTestCumulativeRun(_TestTest):
         if FORKED:
             t.tearDownClass()
 
-        # cumulative cells ran
+        # check cumulative cells ran
         if FORKED:
             t.setUpClass()
         t.setUp()

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -25,6 +25,7 @@ TEST_FAIL = os.path.join(os.path.dirname(__file__), '_test_fail.ipynb')
 # kernel per notebook not per cell, so test like that.
 FRESH_KERNEL_PER_TEST = False
 
+
 def _check_fresh(t, force_fresh=False):
     if FRESH_KERNEL_PER_TEST or force_fresh:
         t.run_test("""
@@ -41,7 +42,7 @@ def _check_fresh(t, force_fresh=False):
 # cleaning up/documenting.
 
 
-def _import_from_path(pypath,f):
+def _import_from_path(pypath, f):
     # TODO consider py version compat
     import importlib.util
     spec = importlib.util.spec_from_file_location(pypath, f)
@@ -56,46 +57,44 @@ class _TestTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         with tempfile.NamedTemporaryFile(suffix='.py') as f:
-            cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s"%(__name__,cls.__name__), run(cls.NBNAME, filename=f.name))
-        
+            cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s" % (__name__, cls.__name__), run(cls.NBNAME, filename=f.name))
+
 
 class TestTestCumulativeRun(_TestTest):
 
     NBNAME = CUMULATIVE_RUN
-    
+
     def test_state(self):
         # TODO: and split up, depending whether testing fresh kernel per test or not
-        
+
         t = self.generated_tests.TestNotebook()
         t.setup_class()
 
-        ######### check cell did not run
+        # check cell did not run
         _check_fresh(t)
         t.test_cell_0()
         _check_fresh(t, force_fresh=True)
 
-
-        ######### check cell ran
+        # check cell ran
         _check_fresh(t)
         t.test_cell_1()
         t.run_test("""
         assert x == 0, x
         """)
-        
-        ######### cumulative cells ran
+
+        # cumulative cells ran
         _check_fresh(t)
         t.test_cell_2()
         t.run_test("""
         assert x == 1, x
         """)
-        
-        ######### check test affects state
+
+        # check test affects state
         _check_fresh(t)
         t.test_cell_3()
         t.run_test("""
         assert x == 2, x
         """)
-
 
         t.teardown_class()
 
@@ -103,15 +102,14 @@ class TestTestCumulativeRun(_TestTest):
 class TestTestCellException(_TestTest):
 
     NBNAME = CELL_ERROR
-    
+
     def test_cell_exception(self):
         t = self.generated_tests.TestNotebook()
         t.setup_class()
 
-
-        ######### cell errors
+        # cell errors
         _check_fresh(t)
-        
+
         try:
             t.test_cell_0()
         except Exception as e:
@@ -120,24 +118,22 @@ class TestTestCellException(_TestTest):
         else:
             raise Exception("Cell should have errored out")
 
-        
         t.teardown_class()
 
 
 class TestTestTestException(_TestTest):
 
     NBNAME = TEST_ERROR
-    
+
     def test_exception_in_test(self):
         t = self.generated_tests.TestNotebook()
         t.setup_class()
 
-
-        ######### caught cell error
+        # caught cell error
         _check_fresh(t)
         t.test_cell_0()
-        
-        ######### test errors
+
+        # test errors
         _check_fresh(t)
         try:
             t.test_cell_1()
@@ -146,33 +142,26 @@ class TestTestTestException(_TestTest):
             assert e.args[0].endswith("My test is bad too")
         else:
             raise Exception("Test should have failed")
-                
 
-        
         t.teardown_class()
 
 
 class TestTestTestFail(_TestTest):
 
     NBNAME = TEST_FAIL
-    
+
     def test_expected_fail(self):
         t = self.generated_tests.TestNotebook()
         t.setup_class()
 
-
-        ######### caught cell error
+        # caught cell error
         _check_fresh(t)
         try:
-            t.test_cell_0()        
+            t.test_cell_0()
         except Exception as e:
             assert e.args[0].startswith("Cell execution caused an exception")
             assert e.args[0].endswith("x should have been -1 but was 1")
         else:
             raise Exception("Test should have failed")
-                
 
-        
         t.teardown_class()
-
-

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -55,8 +55,8 @@ class _TestTest(unittest.TestCase):
     # abstract :)
 
     @classmethod
-    def setUpClass(cls): # TODO dir override is temporary while I figure out azure pipelines...
-        with tempfile.NamedTemporaryFile(suffix='.py',dir=os.path.dirname(__file__)) as f:
+    def setUpClass(cls):  # TODO dir override is temporary while I figure out azure pipelines...
+        with tempfile.NamedTemporaryFile(suffix='.py', dir=os.path.dirname(__file__)) as f:
             cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s" % (__name__, cls.__name__), run(cls.NBNAME, filename=f.name))
 
 

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -60,6 +60,7 @@ class _TestTest(unittest.TestCase):
         tf_name = tf.name
         try:
             cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s" % (__name__, cls.__name__), run(cls.NBNAME, filename=tf_name))
+            tf.close()
         finally:
             os.remove(tf_name)
 

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -55,8 +55,8 @@ class _TestTest(unittest.TestCase):
     # abstract :)
 
     @classmethod
-    def setUpClass(cls):
-        with tempfile.NamedTemporaryFile(suffix='.py') as f:
+    def setUpClass(cls): # TODO dir override is temporary while I figure out azure pipelines...
+        with tempfile.NamedTemporaryFile(suffix='.py',dir=os.path.dirname(__file__)) as f:
             cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s" % (__name__, cls.__name__), run(cls.NBNAME, filename=f.name))
 
 

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -55,9 +55,13 @@ class _TestTest(unittest.TestCase):
     # abstract :)
 
     @classmethod
-    def setUpClass(cls):  # TODO dir override is temporary while I figure out azure pipelines...
-        with tempfile.NamedTemporaryFile(suffix='.py', dir=os.path.dirname(__file__)) as f:
-            cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s" % (__name__, cls.__name__), run(cls.NBNAME, filename=f.name))
+    def setUpClass(cls):
+        tf = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf8')
+        tf_name = tf.name
+        try:
+            cls.generated_tests = _import_from_path("nbcelltests.tests.%s.%s" % (__name__, cls.__name__), run(cls.NBNAME, filename=tf_name))
+        finally:
+            os.remove(tf_name)
 
 
 class TestTestCumulativeRun(_TestTest):

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -30,6 +30,7 @@ EXPECT_FRESH_KERNEL_PER_TEST = True
 # which we are doing via pytest --forked.
 FORKED = '--forked' in sys.argv
 
+
 def _check_fresh(t, override_fresh=False):
     if EXPECT_FRESH_KERNEL_PER_TEST or override_fresh:
         t.run_test("""
@@ -88,7 +89,7 @@ class TestTestCumulativeRun(_TestTest):
         t.tearDown()
         if FORKED:
             t.tearDownClass()
-        
+
         # check cell ran
         if FORKED:
             t.setUpClass()
@@ -104,7 +105,7 @@ class TestTestCumulativeRun(_TestTest):
 
         # cumulative cells ran
         if FORKED:
-            t.setUpClass()        
+            t.setUpClass()
         t.setUp()
         _check_fresh(t)
         t.test_cell_2()
@@ -117,7 +118,7 @@ class TestTestCumulativeRun(_TestTest):
 
         # check test affects state
         if FORKED:
-            t.setUpClass()        
+            t.setUpClass()
         t.setUp()
         _check_fresh(t)
         t.test_cell_3()
@@ -140,7 +141,7 @@ class TestTestCellException(_TestTest):
         t.setUp()
 
         _check_fresh(t, override_fresh=True)
-        
+
         # cell should error out
         try:
             t.test_cell_0()
@@ -163,7 +164,7 @@ class TestTestTestException(_TestTest):
         t.setUpClass()
         t.setUp()
         _check_fresh(t)
-        
+
         # caught cell error
         t.test_cell_0()
 
@@ -175,8 +176,8 @@ class TestTestTestException(_TestTest):
             t.setUpClass()
         t.setUp()
 
-        _check_fresh(t)        
-        
+        _check_fresh(t)
+
         # test should error out
         try:
             t.test_cell_1()
@@ -199,7 +200,7 @@ class TestTestTestFail(_TestTest):
         t.setUpClass()
         t.setUp()
         _check_fresh(t)
-        
+
         # caught cell error
         try:
             t.test_cell_0()
@@ -211,4 +212,3 @@ class TestTestTestFail(_TestTest):
         finally:
             t.tearDown()
             t.tearDownClass()
-

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -69,7 +69,7 @@ class TestNotebook(unittest.TestCase):
     def tearDown(self):
         if ENSURE_FRESH_KERNEL_PER_TEST:
             self.kernel.stop()
-        
+
     def run_test(self, cell_content):
         # This code is from nbval
         # https://github.com/computationalmodelling/nbval

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -109,7 +109,7 @@ class TestNotebook(unittest.TestCase):
             elif msg_type == 'error':
                 traceback = '\\n' + '\\n'.join(reply['traceback'])
                 msg = "Cell execution caused an exception"
-                Exception(msg + '\\n' + traceback)
+                raise Exception(msg + '\\n' + traceback)
 
             # any other message type is not expected
             # should this raise an error?

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -44,13 +44,14 @@ try:
 except ImportError:
     from queue import Empty
 
-KERNEL_NAME = "{kernel_name}"
 
 class TestNotebook(unittest.TestCase):
 
+    KERNEL_NAME = "{kernel_name}"
+
     @classmethod
     def setUpClass(cls):
-        cls.kernel = RunningKernel(KERNEL_NAME)
+        cls.kernel = RunningKernel(cls.KERNEL_NAME)
 
     @classmethod
     def tearDownClass(cls):
@@ -59,7 +60,7 @@ class TestNotebook(unittest.TestCase):
     # TODO: starting a new kernel per test is expensive, and
     # could be optimized.
     def setUp(self):
-        self.kernel = RunningKernel(KERNEL_NAME)
+        self.kernel = RunningKernel(self.KERNEL_NAME)
 
     def tearDown(self):
         self.kernel.stop()

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -47,7 +47,7 @@ except ImportError:
 # if True, ALWAYS starts a new kernel for each test (note that if
 # tests are distributed to independent processes, there will already
 # be a fresh kernel per test so this setting will have no effect)
-ENSURE_FRESH_KERNEL_PER_TEST = False
+ENSURE_FRESH_KERNEL_PER_TEST = True
 
 KERNEL_NAME = "{kernel_name}"
 

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -44,14 +44,32 @@ try:
 except ImportError:
     from queue import Empty
 
+# if True, ALWAYS starts a new kernel for each test (note that if
+# tests are distributed to independent processes, there will already
+# be a fresh kernel per test so this setting will have no effect)
+ENSURE_FRESH_KERNEL_PER_TEST = False
+
+KERNEL_NAME = "{kernel_name}"
+
 
 class TestNotebook(unittest.TestCase):
-    def setup_class(self):
-        self.kernel = RunningKernel("{kernel_name}")
 
-    def teardown_class(self):
-        self.kernel.stop()
+    @classmethod
+    def setUpClass(cls):
+        cls.kernel = RunningKernel(KERNEL_NAME)
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.kernel.stop()
+
+    def setUp(self):
+        if ENSURE_FRESH_KERNEL_PER_TEST:
+            self.kernel = RunningKernel(KERNEL_NAME)
+
+    def tearDown(self):
+        if ENSURE_FRESH_KERNEL_PER_TEST:
+            self.kernel.stop()
+        
     def run_test(self, cell_content):
         # This code is from nbval
         # https://github.com/computationalmodelling/nbval

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -44,13 +44,7 @@ try:
 except ImportError:
     from queue import Empty
 
-# if True, ALWAYS starts a new kernel for each test (note that if
-# tests are distributed to independent processes, there will already
-# be a fresh kernel per test so this setting will have no effect)
-ENSURE_FRESH_KERNEL_PER_TEST = True
-
 KERNEL_NAME = "{kernel_name}"
-
 
 class TestNotebook(unittest.TestCase):
 
@@ -62,13 +56,13 @@ class TestNotebook(unittest.TestCase):
     def tearDownClass(cls):
         cls.kernel.stop()
 
+    # TODO: starting a new kernel per test is expensive, and
+    # could be optimized.
     def setUp(self):
-        if ENSURE_FRESH_KERNEL_PER_TEST:
-            self.kernel = RunningKernel(KERNEL_NAME)
+        self.kernel = RunningKernel(KERNEL_NAME)
 
     def tearDown(self):
-        if ENSURE_FRESH_KERNEL_PER_TEST:
-            self.kernel.stop()
+        self.kernel.stop()
 
     def run_test(self, cell_content):
         # This code is from nbval

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ requires = [
 dev_requires = requires + [
     'bump2version',
     'mock',
-    'autopep8'
+    'autopep8',
+    'pytest-xdist ; sys_platform != "win32"'
 ]
 
 data_spec = [


### PR DESCRIPTION
# Significant behavior changes

* [x] Fix missing raise in "vendored tests" (from nbval). Fixes #91.
* [x] Ensure cells are not executed multiple times in the same kernel. Fixes #94.

# tests_vendored cleanup

* [x] ~~Support always starting a new kernel per test (with option for previous behavior).~~ Always start a new kernel per test. Future work: optimize by tracking cell execution so that each cell is only executed once in any given context. #105 
* [x] Fix tests_vendored method names and make class methods actually be class methods

# New tests

* [x] ~~Test cumulative cell run state (shared kernel)~~ (we are dropping this current behavior)
* [x] Test cumulative cell run state (fresh kernel)
* [x] Test with new process per test
* [x] Test cell exception
* [x] Test test exception
* [x] Test test failure

# Cleanup internal to this PR

* [x] Clean up test_test.py (e.g. fix the enterprise class names, make it possible to understand what is being done, generate the test notebooks, etc - see TODOs).
* [x] ~~If keeping optional 'multiple executions of a cell in same kernel' behavior, make option easily selectable.~~ we are not keeping this behavior

