### PR TITLE
Reduce amount of code stored in string in tests_vendored: import it instead

### DIFF
--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -1,4 +1,15 @@
-# This files includes code copied from nbval under the following license:
+# *****************************************************************************
+#
+# Copyright (c) 2019, the nbcelltests authors.
+#
+# This file is part of the nbcelltests library, distributed under the terms of
+# the Apache License 2.0.  The full license can be found in the LICENSE file.
+#
+
+# TODO go back and get version of nbval it was copied from, and record
+# what modifications have been made.
+
+# This file includes code copied from nbval under the following license:
 # Copyright (C) 2014  Oliver W. Laslett  <O.Laslett@soton.ac.uk>
 #               David Cortes-Ortuno
 #           Maximilian Albert
@@ -36,18 +47,18 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-BASE = '''
-import unittest
-from nbval.kernel import RunningKernel
 try:
     from Queue import Empty
 except ImportError:
     from queue import Empty
 
+import unittest
 
-class TestNotebook(unittest.TestCase):
+from nbval.kernel import RunningKernel
 
-    KERNEL_NAME = "{kernel_name}"
+
+class TestNotebookBase(unittest.TestCase):
+    # abstract - subclasses must define KERNEL_NAME
 
     @classmethod
     def setUpClass(cls):
@@ -66,8 +77,9 @@ class TestNotebook(unittest.TestCase):
         self.kernel.stop()
 
     def run_test(self, cell_content):
-        # This code is from nbval
+        # Start of code from nbval
         # https://github.com/computationalmodelling/nbval
+        # (but note, there are evidently some modifications)
         msg_id = self.kernel.execute_cell_input(cell_content, allow_stdin=False)
 
         # Poll the shell channel to get a message
@@ -128,6 +140,16 @@ class TestNotebook(unittest.TestCase):
             # should this raise an error?
             else:
                 print("unhandled iopub msg:", msg_type)
+
+        # End of code from nbval
+
+
+BASE = '''
+from nbcelltests.tests_vendored import TestNotebookBase
+
+class TestNotebook(TestNotebookBase):
+
+    KERNEL_NAME = "{kernel_name}"
 '''
 
 JSON_CONFD = '''


### PR DESCRIPTION
Note: in its current form, depends on #90 

While I think it might be possible to take an entirely different approach to testing notebooks, at least moving most of the code in `tests_vendored` out of a string will:
  * make it easier to work with the code
  * allow the code to be tested and linted
  * prevent each generated test script having the "run test" machinery vendored in (e.g. what if there's a bug in the run tests code...you'd have to update every generated test script...)

The downside is that the generated test script depends on `nbcelltests.tests_vendored`. But that doesn't seem unreasonable to me. What do you think?

Or if there are other downsides, please let me know!

This PR doesn't represent how I think things should be organized, but I first want to find out if there are any objections to the approach.

## Example of a generated test script before this PR

```python
import unittest
from nbval.kernel import RunningKernel
try:
    from Queue import Empty
except ImportError:
    from queue import Empty


KERNEL_NAME = "python3"


class TestNotebook(unittest.TestCase):

    @classmethod
    def setUpClass(cls):
        cls.kernel = RunningKernel(KERNEL_NAME)

    @classmethod
    def tearDownClass(cls):
        cls.kernel.stop()

    def setUp(self):
        self.kernel = RunningKernel(KERNEL_NAME)

    def tearDown(self):
        self.kernel.stop()

    def run_test(self, cell_content):
        # This code is from nbval
        # https://github.com/computationalmodelling/nbval
        msg_id = self.kernel.execute_cell_input(cell_content, allow_stdin=False)

        # Poll the shell channel to get a message
        try:
            self.kernel.await_reply(msg_id)
        except Empty:
            raise Exception('Kernel timed out waiting for message!')

        while True:
            # The iopub channel broadcasts a range of messages. We keep reading
            # them until we find the message containing the side-effects of our
            # code execution.
            try:
                # Get a message from the kernel iopub channel
                msg = self.kernel.get_message(stream='iopub')

            except Empty:
                raise Exception('Kernel timed out waiting for message!')

            # now we must handle the message by checking the type and reply
            # info and we store the output of the cell in a notebook node object
            msg_type = msg['msg_type']
            reply = msg['content']

            # Is the iopub message related to this cell execution?
            if msg['parent_header'].get('msg_id') != msg_id:
                continue

            # When the kernel starts to execute code, it will enter the 'busy'
            # state and when it finishes, it will enter the 'idle' state.
            # The kernel will publish state 'starting' exactly
            # once at process startup.
            if msg_type == 'status':
                if reply['execution_state'] == 'idle':
                    break
                else:
                    continue
            elif msg_type == 'execute_input':
                continue
            elif msg_type.startswith('comm'):
                continue
            elif msg_type == 'execute_reply':
                continue
            elif msg_type in ('display_data', 'execute_result'):
                continue
            elif msg_type == 'stream':
                continue

            # if the message type is an error then an error has occurred during
            # cell execution. Therefore raise a cell error and pass the
            # traceback information.
            elif msg_type == 'error':
                traceback = '\n' + '\n'.join(reply['traceback'])
                msg = "Cell execution caused an exception"
                raise Exception(msg + '\n' + traceback)

            # any other message type is not expected
            # should this raise an error?
            else:
                print("unhandled iopub msg:", msg_type)

    def test_cell_0(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        """)

    def test_cell_1(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        """)

    def test_cell_2(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        # Cell {2} content

        df['date'] = df.index

        assert df.equals(pd.DataFrame([{'1': 1, '2': 2}]))
        """)

    def test_cell_3(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        # Cell {2} content

        df['date'] = df.index

        assert df.equals(pd.DataFrame([{'1': 1, '2': 2}]))
        """)

    def test_cell_4(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        # Cell {2} content

        df['date'] = df.index

        assert df.equals(pd.DataFrame([{'1': 1, '2': 2}]))
        with patch('pandas.DataFrame.head') as mock:
            # Cell {4} content

            

        """)
```

## And with this PR

```python

from nbcelltests.tests_vendored import TestNotebookBase

class TestNotebook(TestNotebookBase):

    KERNEL_NAME = "python3"

    def test_cell_0(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        """)

    def test_cell_1(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        """)

    def test_cell_2(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        # Cell {2} content

        df['date'] = df.index

        assert df.equals(pd.DataFrame([{'1': 1, '2': 2}]))
        """)

    def test_cell_3(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        # Cell {2} content

        df['date'] = df.index

        assert df.equals(pd.DataFrame([{'1': 1, '2': 2}]))
        """)

    def test_cell_4(self):
        self.run_test("""
        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {0} content

            import cufflinks as cf
            df = cf.datagen.lines()

        from mock import patch
        import pandas as pd
        with patch('cufflinks.datagen.lines') as mock:
            mock.return_value = pd.DataFrame([{'1': 1, '2': 2}])
            # Cell {1} content

            df.head()

        # Cell {2} content

        df['date'] = df.index

        assert df.equals(pd.DataFrame([{'1': 1, '2': 2}]))
        with patch('pandas.DataFrame.head') as mock:
            # Cell {4} content

            

        """)
```

