### PR TITLE
Fix code/test correspondence; explicitly skip test empty cells/tests.

### DIFF
--- a/nbcelltests/shared.py
+++ b/nbcelltests/shared.py
@@ -65,13 +65,6 @@ class MagicsRecorder(ast.NodeVisitor):
                 self.seen.add(magic_name)
 
 
-def extract_cellsources(notebook):
-    return [c['source'].split('\n') for c in notebook.cells if c.get('cell_type') == 'code']
-
-
-def extract_celltests(notebook):
-    return [c['metadata'].get('tests', []) for c in notebook.cells]
-
 
 # Note: I think it's confusing to insert the actual counts into the
 # metadata.  Why not keep them separate?
@@ -113,6 +106,7 @@ def extract_extrametadata(notebook, override=None):
     base['cell_lines'] = []
 
     for c in notebook.cells:
+        # TODO if not c['cell_type'] == 'source'
         if c.get('cell_type') in ('markdown', 'raw',):
             continue
 

--- a/nbcelltests/shared.py
+++ b/nbcelltests/shared.py
@@ -65,7 +65,6 @@ class MagicsRecorder(ast.NodeVisitor):
                 self.seen.add(magic_name)
 
 
-
 # Note: I think it's confusing to insert the actual counts into the
 # metadata.  Why not keep them separate?
 #

--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -12,41 +12,81 @@ import shutil
 import sys
 import subprocess
 import tempfile
+import ast
 from .define import TestMessage, TestType
-from .shared import extract_cellsources, extract_celltests, extract_extrametadata
+from .shared import extract_extrametadata
 from .tests_vendored import BASE, JSON_CONFD
+
+# TODO: eventually want assemble() and the rest to be doing something
+# better than building up code in strings. It's tricky to work with,
+# tricky to read, can't lint, can't test easily, unlikely to be
+# generally correct, etc etc :)
+
+# TODO: there are multiple definitions of "is tested", "is code cell"
+# throughout the code.
 
 INDENT = '    '
 
 
-def assemble_code(sources, tests):
+def _is_empty(source):
+    # TODO: py2 utf8
+    return len(ast.parse(source).body) == 0
+
+
+def _cell_source_is_injected(test_lines):
+    for test_line in test_lines:
+        if test_line.strip().startswith(r"%cell"):
+            return True
+    return False
+
+
+def assemble_code(notebook):
     cells = []
+    code_cell = 0
+    # notes:
+    #   * code cell counting is 1 based
+    #   * the only import in the template is nbcelltests.tests_vendored
+    for i, cell in enumerate(notebook.cells, start=1):
+        # TODO: duplicate definition how to get tests
+        test_lines = cell.get('metadata', {}).get('tests', [])
 
-    # for cell of notebook,
-    # assemble code to write
-    for i, [code, test] in enumerate(zip(sources, tests)):
-        # add celltest
-        cells.append([i, [], 'def test_cell_%d(self):\n' % i])
+        if cell.get('cell_type') != 'code':
+            if len(test_lines) > 0:
+                raise ValueError("Cell %d is not a code cell, but metadata contains test code!" % i)
+            continue
 
-        for line in test:
-            # if testing the cell,
-            # write code from cell
-            if line.strip().startswith(r'%cell'):
+        code_cell += 1
 
+        if _is_empty(cell['source']):
+
+            skiptest = "@nbcelltests.tests_vendored.unittest.skip('empty code cell')\n" + INDENT
+        elif _is_empty("".join(test_lines).replace(r"%cell", "pass")):
+            skiptest = "@nbcelltests.tests_vendored.unittest.skip('no test supplied')\n" + INDENT
+        elif not _cell_source_is_injected(test_lines):
+            skiptest = "@nbcelltests.tests_vendored.unittest.skip('cell code not injected into test')\n" + INDENT
+        else:
+            skiptest = ""
+
+        cells.append([i, [], "%sdef test_code_cell_%d(self):\n" % (skiptest, code_cell)])
+
+        if skiptest:
+            cells[-1][1].append(INDENT + 'pass # code cell %d\n\n' % code_cell)
+            continue
+
+        for test_line in test_lines:
+            if test_line.strip().startswith(r"%cell"):
                 # add comment in test for readability
-                cells[-1][1].append(INDENT + line.replace(r'%cell', '# Cell {' + str(i) + '} content\n'))
+                cells[-1][1].append(INDENT + test_line.replace(r'%cell', '# Cell {' + str(code_cell) + '} content\n'))
 
                 # add all code for cell
-                for c in code:
-                    cells[-1][1].append(INDENT + line.replace('\n', '').replace(r'%cell', '') + c + '\n')
-
-                cells[-1][1].append('\n')
+                for cell_line in cell['source'].split('\n'):
+                    # TODO: is this going to replace %cell appearing in a comment?
+                    cells[-1][1].append(INDENT + test_line.replace('\n', '').replace(r'%cell', '') + cell_line + '\n')
 
             # else just write test
             else:
-                cells[-1][1].append(INDENT + line)
-                if not line[-1] == '\n':
-                    # add newline if missing
+                cells[-1][1].append(INDENT + test_line)
+                if not test_line[-1] == '\n':
                     cells[-1][1][-1] += '\n'
 
     return cells
@@ -126,12 +166,8 @@ def run(notebook, rules=None, filename=None):
     name = filename or notebook[:-6] + '_test.py'  # remove .ipynb, replace with _test.py
 
     kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
-
-    sources = extract_cellsources(nb)
-    tests = extract_celltests(nb)
+    cells = assemble_code(nb)
     extra_metadata = extract_extrametadata(nb)
-    cells = assemble_code(sources, tests)
-
     rules = rules or {}
     extra_metadata.update(rules)
 

--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -29,8 +29,17 @@ INDENT = '    '
 
 
 def _is_empty(source):
+    try:
+        parsed = ast.parse(source)
+    except SyntaxError:
+        # If there's a syntax error, it's not an empty code cell.
+        # Handling and communicating syntax errors is a general issue
+        # (https://github.com/jpmorganchase/nbcelltests/issues/101).
+        # Note: this will also handle magics.
+        return False
+
     # TODO: py2 utf8
-    return len(ast.parse(source).body) == 0
+    return len(parsed.body) == 0
 
 
 def _cell_source_is_injected(test_lines):

--- a/nbcelltests/tests/_cell_counting.ipynb
+++ b/nbcelltests/tests/_cell_counting.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tests": [
+     "assert x == 1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "some markdown"
+   ],   
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "assert x == 2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 2"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "source": [
+    "raw"
+   ],   
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "assert x == 3"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 3"
+   ]
+  }  
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_non_code_cell.ipynb
+++ b/nbcelltests/tests/_non_code_cell.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "some markdown"
+   ],   
+   "metadata": {
+    "tests": [
+     "# Use %cell to execute the cell\n",
+     "pass\n",
+     "\n"
+    ]
+   }
+  } 
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7.6 64-bit ('celltestsui': conda)",
+   "language": "python",
+   "name": "python37664bitcelltestsuiconda549e14be7f784a2fbde278c18c8be829"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_skips.ipynb
+++ b/nbcelltests/tests/_skips.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tests": [
+     "pass"
+    ]
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# nothing to see here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tests": [
+     "# nothing to see here"
+    ]
+   },   
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tests": []
+   },   
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tests": [
+     "x = 2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -75,7 +75,7 @@ def _generate_test_module(notebook, module_name):
     finally:
         try:
             tf.close()
-        except:
+        except Exception:
             pass
         os.remove(tf_name)
 

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -10,7 +10,7 @@ import os
 import sys
 import unittest
 
-from nbcelltests.test import run
+from nbcelltests.test import run, _is_empty
 
 # TODO: we should generate the notebooks rather than having them as
 # files (same for lint ones). Would also allow for simplification of
@@ -380,3 +380,12 @@ class TestCellCounting(_TestCellTests):
         """No unexpected extra test methods"""
         test_methods = [mthd for mthd in dir(self.t) if mthd.startswith("test_code_cell")]
         self.assertListEqual(sorted(test_methods), ['test_code_cell_1', 'test_code_cell_2', 'test_code_cell_3'])
+
+
+def test_is_empty():
+    assert _is_empty("import blah\nblah.do_something()") is False
+    assert _is_empty("%matplotlib inline") is False
+    assert _is_empty("pass") is False
+    assert _is_empty("") is True
+    assert _is_empty("#pass") is True
+    assert _is_empty("\n\n\n") is True

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -71,11 +71,15 @@ def _generate_test_module(notebook, module_name):
         # the module name (__name__) doesn't really matter, but
         # will be nbcelltests.tests.test_tests.X, where X is
         # whatever concrete subclass is this method belongs to.
-        generated_tests = _import_from_path(run(notebook, filename=tf_name), module_name)
-        tf.close()
-        return generated_tests
+        generated_module = _import_from_path(run(notebook, filename=tf_name), module_name)
     finally:
+        try:
+            tf.close()
+        except:
+            pass
         os.remove(tf_name)
+
+    return generated_module
 
 
 class _TestCellTests(unittest.TestCase):

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -12,12 +12,16 @@ import unittest
 
 from nbcelltests.test import run
 
-# TODO: we should generate the notebooks rather than having them as files
-# (same for lint ones)
+# TODO: we should generate the notebooks rather than having them as
+# files (same for lint ones). Would also allow for simplification of
+# test class hierarchy.
 CUMULATIVE_RUN = os.path.join(os.path.dirname(__file__), '_cumulative_run.ipynb')
 CELL_ERROR = os.path.join(os.path.dirname(__file__), '_cell_error.ipynb')
 TEST_ERROR = os.path.join(os.path.dirname(__file__), '_test_error.ipynb')
 TEST_FAIL = os.path.join(os.path.dirname(__file__), '_test_fail.ipynb')
+COUNTING = os.path.join(os.path.dirname(__file__), '_cell_counting.ipynb')
+NONCODE = os.path.join(os.path.dirname(__file__), '_non_code_cell.ipynb')
+SKIPS = os.path.join(os.path.dirname(__file__), '_skips.ipynb')
 
 # Hack. We want to test expected behavior in distributed situation,
 # which we are doing via pytest --forked.
@@ -39,10 +43,6 @@ def _assert_x_undefined(t):
 
 # TODO: This test file's manual use of unittest is brittle
 
-# TODO: generated test methods are 0 based, but jupyter is typically 1
-# based. To be fixed in
-# https://github.com/jpmorganchase/nbcelltests/issues/99.
-
 
 def _import_from_path(path, module_name):
     """
@@ -60,28 +60,107 @@ def _import_from_path(path, module_name):
     return mod
 
 
+def _generate_test_module(notebook, module_name):
+    """
+    Generate test file from notebook, then import it with __name__ set
+    to module_name, and return it.
+    """
+    tf = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf8')
+    tf_name = tf.name
+    try:
+        # the module name (__name__) doesn't really matter, but
+        # will be nbcelltests.tests.test_tests.X, where X is
+        # whatever concrete subclass is this method belongs to.
+        generated_tests = _import_from_path(run(notebook, filename=tf_name), module_name)
+        tf.close()
+        return generated_tests
+    finally:
+        os.remove(tf_name)
+
+
 class _TestCellTests(unittest.TestCase):
     # abstract :)
 
     @classmethod
     def setUpClass(cls):
-        """
-        Generate test file from notebook, then import it, and make the
-        resulting module available as "generated_tests" class attribute.
-        """
-        tf = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf8')
-        tf_name = tf.name
+        assert hasattr(cls, "NBNAME"), "Subclasses must have NBNAME attribute."  # TODO: make actually abstract
+        cls.generated_tests = _generate_test_module(notebook=cls.NBNAME, module_name="nbcelltests.tests.%s.%s" % (__name__, cls.__name__))
+
+    def _assert_skipped(self, mthd, reason):
+        # TODO: actually calling the skipped method here ends
+        # everything! It's some pytest issue, I think. So for now we
+        # are checking that it would be skipped, rather than that it is
+        # definitely skipped.
+        msg = "Should have generated a skipped test method"
+        self.assertTrue(hasattr(mthd, '__unittest_skip__'), msg=msg)
+        self.assertEqual(mthd.__unittest_skip__, True, msg=msg)
+        self.assertEqual(mthd.__unittest_skip_why__, reason, msg="Skip reason should have been %s" % reason)
+
+
+class TestMethodGenerationError(_TestCellTests):
+    """Tests of things that should fail during test script generation"""
+
+    NBNAME = NONCODE
+
+    @classmethod
+    def setUpClass(cls):
+        # we're testing what happens in setUpClass
+        pass
+
+    def test_non_code_cell_with_test_causes_error(self):
         try:
-            # the module name (__name__) doesn't really matter, but
-            # will be nbcelltests.tests.test_tests.X, where X is
-            # whatever concrete subclass is this method belongs to.
-            cls.generated_tests = _import_from_path(path=run(cls.NBNAME, filename=tf_name), module_name="nbcelltests.tests.%s.%s" % (__name__, cls.__name__))
-            tf.close()
-        finally:
-            os.remove(tf_name)
+            _generate_test_module(self.NBNAME, "module.name.irrelevant")
+        except ValueError as e:
+            assert e.args[0] == 'Cell 1 is not a code cell, but metadata contains test code!'
+        else:
+            raise Exception("Test script should fail to generate")
+
+
+class TestSkips(_TestCellTests):
+    """Tests that various conditions result in skipped tests"""
+
+    NBNAME = SKIPS
+
+    # the tests are independent, so it's fine to call setUpClass and
+    # setUp before every test (and same for tearDown after). When we
+    # are generating notebooks, we won't need the single, shared
+    # notebook.
+    def setUp(self):
+        self.t = self.generated_tests.TestNotebook()
+        self.t.setUpClass()
+        self.t.setUp()
+
+    def tearDown(self):
+        self.t.tearDown()
+        self.t.tearDownClass()
+
+    def test_skip_completely_empty_code_cell(self):
+        """Test+cell where cell has nothing at all in should be skipped"""
+        self._assert_skipped(self.t.test_code_cell_1, "empty code cell")
+
+    def test_skip_no_code_code_cell(self):
+        """Test+cell where cell had e.g. just a comment in should be skipped"""
+        self._assert_skipped(self.t.test_code_cell_2, "empty code cell")
+
+    def test_skip_no_test_field_in_metadata(self):
+        """Cell with no test metadata should be skipped"""
+        self._assert_skipped(self.t.test_code_cell_3, "no test supplied")
+
+    def test_skip_no_code_in_test(self):
+        """Test+cell where test is just e.g. a comment should be skipped"""
+        self._assert_skipped(self.t.test_code_cell_4, "no test supplied")
+
+    def test_skip_completely_empty_test(self):
+        """Cell where test is completely empty should be skipped"""
+        self._assert_skipped(self.t.test_code_cell_5, "no test supplied")
+
+    def test_skip_if_no_cell_injection(self):
+        """Test+cell where test does not inject cell should be skipped"""
+        self._assert_skipped(self.t.test_code_cell_6, "cell code not injected into test")
 
 
 class TestCumulativeRun(_TestCellTests):
+    """Tests that state in notebook is built up correctly."""
 
     NBNAME = CUMULATIVE_RUN
 
@@ -110,6 +189,9 @@ class TestCumulativeRun(_TestCellTests):
         4:   x+=1     -      x>2   (bad)
         5:    -      x+=1    x>3   (bad)
         """
+        # this is one long method rather individual ones because of
+        # building up state
+
         t = self.generated_tests.TestNotebook()
         t.setUpClass()
 
@@ -117,8 +199,9 @@ class TestCumulativeRun(_TestCellTests):
         # (no %cell in test)
         t.setUp()
         _assert_x_undefined(t)
-        t.test_cell_0()
-        _assert_x_undefined(t)
+        self._assert_skipped(t.test_code_cell_1, "cell code not injected into test")
+        # t.test_code_cell_1()
+        # _assert_x_undefined(t)
         t.tearDown()
         if FORKED:
             t.tearDownClass()
@@ -128,7 +211,7 @@ class TestCumulativeRun(_TestCellTests):
         if FORKED:
             t.setUpClass()
         t.setUp()
-        t.test_cell_1()
+        t.test_code_cell_2()
         t.run_test("""
         assert x == 0, x
         """)
@@ -140,7 +223,7 @@ class TestCumulativeRun(_TestCellTests):
         if FORKED:
             t.setUpClass()
         t.setUp()
-        t.test_cell_2()
+        t.test_code_cell_3()
         t.run_test("""
         assert x == 1, x
         """)
@@ -152,7 +235,7 @@ class TestCumulativeRun(_TestCellTests):
         if FORKED:
             t.setUpClass()
         t.setUp()
-        t.test_cell_3()
+        t.test_code_cell_4()
         t.run_test("""
         assert x == 2, x
         """)
@@ -164,7 +247,7 @@ class TestCumulativeRun(_TestCellTests):
         if FORKED:
             t.setUpClass()
         t.setUp()
-        t.test_cell_4()
+        t.test_code_cell_5()
         t.run_test("""
         assert x == 3, x
         """)
@@ -174,6 +257,7 @@ class TestCumulativeRun(_TestCellTests):
 
 
 class TestExceptionInCell(_TestCellTests):
+    """Tests related to exceptions in cells"""
 
     NBNAME = CELL_ERROR
 
@@ -185,7 +269,7 @@ class TestExceptionInCell(_TestCellTests):
 
         # cell should error out
         try:
-            t.test_cell_0()
+            t.test_code_cell_1()
         except Exception as e:
             assert e.args[0].startswith("Cell execution caused an exception")
             assert e.args[0].endswith("My code does not even run")
@@ -197,6 +281,7 @@ class TestExceptionInCell(_TestCellTests):
 
 
 class TestExceptionInTest(_TestCellTests):
+    """Tests related to exeptions in tests"""
 
     NBNAME = TEST_ERROR
 
@@ -206,7 +291,7 @@ class TestExceptionInTest(_TestCellTests):
         t.setUp()
 
         # caught cell error
-        t.test_cell_0()
+        t.test_code_cell_1()
 
         t.tearDown()
         if FORKED:
@@ -220,7 +305,7 @@ class TestExceptionInTest(_TestCellTests):
 
         # test should error out
         try:
-            t.test_cell_1()
+            t.test_code_cell_2()
         except Exception as e:
             assert e.args[0].startswith("Cell execution caused an exception")
             assert e.args[0].endswith("My test is bad too")
@@ -232,17 +317,18 @@ class TestExceptionInTest(_TestCellTests):
 
 
 class TestFailureInTest(_TestCellTests):
+    """Tests related to test failures"""
 
     NBNAME = TEST_FAIL
 
     def test_failure_is_detected(self):
+        """Test expected to fail - make sure we detect that."""
         t = self.generated_tests.TestNotebook()
         t.setUpClass()
         t.setUp()
 
-        # caught cell error
         try:
-            t.test_cell_0()
+            t.test_code_cell_1()
         except Exception as e:
             assert e.args[0].startswith("Cell execution caused an exception")
             assert e.args[0].endswith("x should have been -1 but was 1")
@@ -251,3 +337,42 @@ class TestFailureInTest(_TestCellTests):
         finally:
             t.tearDown()
             t.tearDownClass()
+
+
+class TestCellCounting(_TestCellTests):
+    """Check that various things don't throw off cell+test correspondence."""
+
+    NBNAME = COUNTING
+
+    # the tests are independent, so it's fine to call setUpClass and
+    # setUp before every test (and same for tearDown after). When we
+    # are generating notebooks, we won't need the single, shared
+    # notebook.
+    def setUp(self):
+        self.t = self.generated_tests.TestNotebook()
+        self.t.setUpClass()
+        self.t.setUp()
+
+    def tearDown(self):
+        self.t.tearDown()
+        self.t.tearDownClass()
+
+    def test_skips(self):
+        """
+        There's a skipped test at the start of the notebook to make sure skips don't
+        affect test/cell correspondence.
+        """
+        self._assert_skipped(self.t.test_code_cell_1, "cell code not injected into test")
+
+    def test_still_ok_after_markdown(self):
+        """Correspondence still ok after markdown cell?"""
+        self.t.test_code_cell_2()
+
+    def test_still_ok_after_raw(self):
+        """Correspondence still ok after raw cell?"""
+        self.t.test_code_cell_3()
+
+    def test_count(self):
+        """No unexpected extra test methods"""
+        test_methods = [mthd for mthd in dir(self.t) if mthd.startswith("test_code_cell")]
+        self.assertListEqual(sorted(test_methods), ['test_code_cell_1', 'test_code_cell_2', 'test_code_cell_3'])

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -145,11 +145,11 @@ class TestNotebookBase(unittest.TestCase):
 
 
 BASE = '''
-from nbcelltests.tests_vendored import TestNotebookBase
+import nbcelltests.tests_vendored
 
-class TestNotebook(TestNotebookBase):
-
+class TestNotebook(nbcelltests.tests_vendored.TestNotebookBase):
     KERNEL_NAME = "{kernel_name}"
+
 '''
 
 JSON_CONFD = '''


### PR DESCRIPTION
Fixes #97 and fixes #99. Same tests as in #111, just updated for 1-based counting.

## Summary of new behavior

1. Test methods are only generated for code cells. If a non-code cell contains a test in its metadata, it's an error at generation time. Only code cells will be included in "cell coverage" calculation.

2. Test methods are named like `test_code_cell_n` (so you know it's only code cells), where `n` is the 1-based code cell number - i.e. they are numbered like execution count (if run from scratch).

Example: If there are 3 cells, and the 2nd cell is markdown, then there'll just be two test methods, `test_code_cell_1` and `test_code_cell_2`.

3. Code cells that are empty or do not have a test still generate a test method, but decorated with `@skip(reason)` (where `reason` is `"empty code cell"` or `"cell has no test"`). 

4. Tests that do not contain a cell injection generate a skipped test method (`reason` is `"no cell injection"`).

## Changes in this PR

* Fix correspondence of code and test cells (e.g. markdown caused them to go out of sync)

* Change cell/test numbering to start from 1, and only include code cells (matching other notebook tools).

* If a non-code cell contains test in metadata, it's an error during test script generation.

* Create explicitly skipped tests for:
    * empty cell
    * empty test
    * code cell not injected into test

To do:
  * [x] Fix windows tests

Future work:
  * Update coverage calculation (see https://github.com/jpmorganchase/nbcelltests/pull/112#issuecomment-630909164)

EDIT: clarified that coverage will be addressed in a subsequent PR once behavior here is agreed.