### PR TITLE
Don't count empty code cells for lint's "max cells per nb" or for coverage

### DIFF
--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -12,7 +12,6 @@ import shutil
 import sys
 import subprocess
 import tempfile
-import ast
 from .define import TestMessage, TestType
 from .shared import extract_extrametadata, get_coverage, is_empty, cell_injected_into_test
 from .tests_vendored import BASE, JSON_CONFD

--- a/nbcelltests/tests/coverage.ipynb
+++ b/nbcelltests/tests/coverage.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tests": [
+     "assert x == 1\n",
+     "class X: pass"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# nothing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "def f(x): return x\n",
+    "class X: pass"
+   ],   
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "def f(x): return x"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def f(x): return x\n",
+    "f(1)\n",
+    "f(2)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "source": [
+    "class X: pass\n",
+    "%magics3"
+   ],   
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tests": [
+     "assert x == 3\n",
+     "%magics1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tests": []
+   },
+   "outputs": [],
+   "source": [
+    "x = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%magics2\n",
+    "class X: pass"
+   ]
+  }      
+ ],
+ "metadata": {
+  "celltests": {
+   "cell_coverage": 50
+  }, 
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/test_lint.py
+++ b/nbcelltests/tests/test_lint.py
@@ -144,13 +144,13 @@ def test_magics_lists_sanity():
         # one rule, pass
         ({'lines_per_cell': -1}, [], True),
         # one rule, fail
-        ({'lines_per_cell': 1}, [LR(x, LintType.LINES_PER_CELL) for x in [False, True, True, True, False, False]], False),
+        ({'lines_per_cell': 1}, [LR(x, LintType.LINES_PER_CELL) for x in [False, True, False, False]], False),
         # multiple rules, combo fail
         ({'lines_per_cell': 5,
-          'cells_per_notebook': 1}, [LR(True, LintType.LINES_PER_CELL)] * 6 + [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
+          'cells_per_notebook': 1}, [LR(True, LintType.LINES_PER_CELL)] * 4 + [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
         # multiple rules, combo pass
         ({'lines_per_cell': 5,
-          'cells_per_notebook': 10}, [LR(True, LintType.LINES_PER_CELL)] * 6 + [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
+          'cells_per_notebook': 10}, [LR(True, LintType.LINES_PER_CELL)] * 4 + [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
         # all the expected rules
         ({'lines_per_cell': 5,
           'cells_per_notebook': 2,
@@ -159,7 +159,7 @@ def test_magics_lists_sanity():
           'cell_coverage': 90,
           'kernelspec_requirements':
             {'name': 'python3'},
-          'magics_whitelist': ['matplotlib']}, [LR(True, LintType.LINES_PER_CELL)] * 6 +
+          'magics_whitelist': ['matplotlib']}, [LR(True, LintType.LINES_PER_CELL)] * 4 +
                                                [LR(False, LintType.CELLS_PER_NOTEBOOK)] +
                                                [LR(False, LintType.FUNCTION_DEFINITIONS)] +
                                                [LR(False, LintType.CLASS_DEFINITIONS)] +

--- a/nbcelltests/tests/test_shared.py
+++ b/nbcelltests/tests/test_shared.py
@@ -9,12 +9,22 @@ import os
 
 import nbformat
 
-from nbcelltests.shared import extract_extrametadata
+from nbcelltests.shared import extract_extrametadata, get_coverage, is_empty
 
-
+# TODO: should generate these
 BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
 MORE_NB = os.path.join(os.path.dirname(__file__), 'more.ipynb')
 MAGICS_NB = os.path.join(os.path.dirname(__file__), 'magics.ipynb')
+COVERAGE_NB = os.path.join(os.path.dirname(__file__), 'coverage.ipynb')
+
+
+def test_is_empty():
+    assert is_empty("import blah\nblah.do_something()") is False
+    assert is_empty("%matplotlib inline") is False
+    assert is_empty("pass") is False
+    assert is_empty("") is True
+    assert is_empty("#pass") is True
+    assert is_empty("\n\n\n") is True
 
 
 def _metadata(nb, what):
@@ -37,6 +47,8 @@ def test_extract_extrametadata_cell_count_basic():
 def test_extract_extrametadata_cell_lines_basic():
     assert _metadata(BASIC_NB, 'cell_lines') == [1] * 5
 
+# with some magics present
+
 
 def test_extract_extrametadata_functions_more():
     assert _metadata(MORE_NB, 'functions') == 1
@@ -47,12 +59,65 @@ def test_extract_extrametadata_classes_more():
 
 
 def test_extract_extrametadata_cell_count_more():
-    assert _metadata(MORE_NB, 'cell_count') == 6
+    assert _metadata(MORE_NB, 'cell_count') == 4
 
 
 def test_extract_extrametadata_cell_lines_more():
-    assert _metadata(MORE_NB, 'cell_lines') == [2] + [1] * 3 + [2, 3]
+    assert _metadata(MORE_NB, 'cell_lines') == [2, 1] + [2, 3]
 
 
 def test_extract_extrametadata_magics():
     assert _metadata(MAGICS_NB, 'magics') == set(['magics1', 'magics2', 'magics3'])
+
+
+# with non-code cells present
+
+
+def test_extract_extrametadata_functions_noncode():
+    assert _metadata(COVERAGE_NB, 'functions') == 1
+
+
+def test_extract_extrametadata_classes_noncode():
+    assert _metadata(COVERAGE_NB, 'classes') == 1
+
+
+def test_extract_extrametadata_cell_count_noncode():
+    assert _metadata(COVERAGE_NB, 'cell_count') == 4
+
+
+def test_extract_extrametadata_cell_lines_noncode():
+    assert _metadata(COVERAGE_NB, 'cell_lines') == [3, 1, 1, 2]
+
+
+def test_extract_extrametadata_magics_noncode():
+    assert _metadata(COVERAGE_NB, 'magics') == set(['magics2'])
+
+
+# coverage
+
+# tests would clearer with multiple notebooks containing independent
+# cases - i.e. should generate them
+
+# N = contribs to numerator of calc
+# D = contribs to denominator of calc
+# - = contribs nothing
+
+# --  empty code cell with test
+# --  markdown cell
+# ND  code cell with valid test
+# --  raw cell
+# -D  code cell with invalid test (no %cell)
+# -D  code cell with empty test
+# -D  code cell with no test
+#
+# i.e. coverage = 1/4
+def test_extract_extrametadata_cell_count_coverage():
+    assert _metadata(COVERAGE_NB, 'cell_count') == 4
+
+
+def test_extract_extrametadata_cell_test_coverage():
+    assert _metadata(COVERAGE_NB, 'test_count') == 1
+
+
+def test_get_coverage():
+    assert get_coverage(extract_extrametadata(nbformat.read(COVERAGE_NB, 4))) == 25


### PR DESCRIPTION
Tests: fixes #118
Lint: closes #83

Notes:
* Fixed `shared.get_coverage()`, which was completely broken, and was apparently unused (definitely untested).
* Reduced number of times "is cell tested?" is defined.

Question: is there any point offering an option to count the old way, i.e. to count empty cells if preferred. In #83 I speculated that someone might want to limit the number of empty cells (e.g. so their notebooks look nice!), but on reflection I agree with @vidartf that it's not necessary (i.e. I vote "no").
