### PR TITLE
Add python 3.6 and 3.8 to azure build matrix.

### DIFF
--- a/.azure/template.yml
+++ b/.azure/template.yml
@@ -10,8 +10,12 @@ jobs:
 
   strategy:
     matrix:
+      Python36:
+        python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
 
   steps:
   - task: UsePythonVersion@0


### PR DESCRIPTION
Fixes #106