### PR TITLE
More release fixups

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -48,10 +48,10 @@ stages:
       displayName: 'Create packages'
     - task: TwineAuthenticate@0
       inputs:
-        artifactFeeds: jupyter/python-packages
+        artifactFeeds: jupyter/packages-testing
     # TODO: replace with: env vars and make publishpy
     - script: |
-        twine check dist/* && twine upload -r jupyter/python-packages --config-file $(PYPIRC_PATH) dist/*
+        twine check dist/* && twine upload -r jupyter/packages-testing --config-file $(PYPIRC_PATH) dist/*
       displayName: 'Upload packages'
     # equivalent of "make publishjs", but to azure feed
     - task: Npm@1
@@ -59,4 +59,4 @@ stages:
         command: publish
         workingDir: js
         publishRegistry: useFeed
-        publishFeed: jupyter/python-packages
+        publishFeed: jupyter/packages-testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,12 +59,12 @@ To make a new release of nbcelltests:
 3. `git tag -a v0.2.0a0 "Release new alpha"`
 4. `git push origin && git push origin --tags v0.2.0a0` - This will push the tag you created above, which will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages).
 5. Check the resulting packages:
-  - Install and test in a clean environment:
-    - You can install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ nbcelltests==0.2.0a0 --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist, and to install the version you want to test. Following that, you should at least run the installed package's tests (after installing the test dependencies - see setup.py's dev dependencies): `python -m py.test --pyargs nbcelltests`.
-    - Download the nbcelltests npm package from [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages) and then install with `jupyter labextension install /path/to/nbcelltests-0.2.0-alpha.0.tgz` (replacing the filename with whatever you downloaded).
-  - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
+    - Install and test in a clean environment:
+        - You can install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ nbcelltests==0.2.0a0 --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist, and to install the version you want to test. Following that, you should at least run the installed package's tests (after installing the test dependencies - see setup.py's dev dependencies): `python -m py.test --pyargs nbcelltests`.
+        - Download the nbcelltests npm package from [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages) and then install with `jupyter labextension install /path/to/nbcelltests-0.2.0-alpha.0.tgz` (replacing the filename with whatever you downloaded).
+    - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
 6. You can upload release candidates to pypi and npm if you want:
-  - pypi: `twine check /path/to/dist/* && twine upload /path/to/dist/*` (updating the path to match what you downloaded from azure).
-  - npm: `npm publish --tag beta /path/to/nbcelltests-0.2.0-alpha.0.tgz` (updating the filename to match what you downloaded from azure).
+    - pypi: `twine check /path/to/dist/* && twine upload /path/to/dist/*` (updating the path to match what you downloaded from azure).
+    - npm: `npm publish --tag beta /path/to/nbcelltests-0.2.0-alpha.0.tgz` (updating the filename to match what you downloaded from azure).
 7. Once satisfied, use `bumpversion` either to set or increment `release` to `final` (e.g.  `bumpversion release`), and then repeat steps 3 and 4. Grab the resulting releases from azure and upload to pypi and npm.
 8. At some point after this (?), someone should bump the version to something something alpha (?).

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_celltests",
-  "version": "0.2.0",
+  "version": "0.2.0-alpha.0",
   "description": "A JupyterLab extension for cell-by-cell testing and linting of notebooks.",
   "author": "The nbcelltests authors",
   "main": "lib/index.js",

--- a/nbcelltests/_version.py
+++ b/nbcelltests/_version.py
@@ -12,7 +12,7 @@ VersionInfo = namedtuple('VersionInfo', [
 ])
 
 # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
-version_info = VersionInfo(0, 2, 0, 'final', 0)
+version_info = VersionInfo(0, 2, 0, 'alpha', 0)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 


### PR DESCRIPTION
1. Change azure feed name from `python-packages` to `packages-testing` (#67) to denote that (a) it's not only for python packages (named it before I knew what I was clicking in azure...) and (b) it's for test packages (official releases are on pypi/npm). See also https://github.com/timkpaine/jupyterlab_autoversion/pull/24. If both that PR and this PR are merged, we should probably just delete https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages (shouldn't matter as it's only a test channel; the packages are on pypi/npm).

2. In #133 I manually modified the version in `.bumpversion.cfg`, forgetting that the same info is also stored in `nbcelltests/_version.py` and `js/package.json` - so fix up those two versions also.

3. Formatting fix in CONTRIBUTING.