### PR TITLE
Bump version: (0, 2, 0, 'alpha', 0) → 0, 2, 0, 'alpha', 1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = (0, 2, 0, 'alpha', 0)
+current_version = 0, 2, 0, 'alpha', 1
 commit = True
 tag = False
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_celltests",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.1",
   "description": "A JupyterLab extension for cell-by-cell testing and linting of notebooks.",
   "author": "The nbcelltests authors",
   "main": "lib/index.js",

--- a/nbcelltests/_version.py
+++ b/nbcelltests/_version.py
@@ -12,7 +12,7 @@ VersionInfo = namedtuple('VersionInfo', [
 ])
 
 # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
-version_info = VersionInfo(0, 2, 0, 'alpha', 0)
+version_info = VersionInfo(0, 2, 0, 'alpha', 1)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 


### PR DESCRIPTION
Release 0.2.0a1. Should be the last pre-release - everything seems ok now.

P. S. A downside with this workflow is the releaser needs to get these kinds of trivial commits reviewed. If I attempt to push to jpmorganchase/nbcelltests' master:
```
$ git push upstream master
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.
Delta compression using up to 12 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 599 bytes | 599.00 KiB/s, done.
Total 7 (delta 6), reused 0 (delta 0)
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: 4 of 4 required status checks have not succeeded: 3 expected. At least 1 approving review is required by reviewers with write access.
To github.com:jpmorganchase/nbcelltests.git
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'git@github.com:jpmorganchase/nbcelltests.git'
```
But maybe that's fine. Anyway, we should discuss this as a cross-repo issue in the future. (Tools like versioneer allow versions to be managed purely by the git tag; having only one source of truth for the version is great, but there are other downsides to that approach.)