### PR TITLE
Fix lab extension bundling and speculative installation

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -19,7 +19,7 @@ stages:
     parameters:
       name: 'Mac'
       pool:
-        vmImage: 'macos-10.14'  
+        vmImage: 'macos-10.14'
   - template: dev-template.yml
     parameters:
       name: 'Windows'
@@ -60,3 +60,23 @@ stages:
         workingDir: js
         publishRegistry: useFeed
         publishFeed: jupyter/packages-testing
+
+- stage: package-test
+  displayName: Install and test packages as a user
+  condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/tags/v'))
+  jobs:
+  - template: test-template.yml
+    parameters:
+      name: 'Linux'
+      pool:
+        vmImage: 'ubuntu-latest'
+  - template: test-template.yml
+    parameters:
+      name: 'Mac'
+      pool:
+        vmImage: 'macos-10.14'
+  - template: test-template.yml
+    parameters:
+      name: 'Windows'
+      pool:
+        vmImage: 'vs2017-win2016'

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -61,7 +61,7 @@ stages:
         publishRegistry: useFeed
         publishFeed: jupyter/packages-testing
 
-- stage: package-test
+- stage: package_test
   displayName: Install and test packages as a user
   condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/tags/v'))
   jobs:

--- a/.azure/test-template.yml
+++ b/.azure/test-template.yml
@@ -38,6 +38,7 @@ jobs:
       jupyter labextension check jupyterlab_celltests
       python -c "import subprocess,re,sys; import nbcelltests;  ext=subprocess.check_output(['jupyter','serverextension','list'],stderr=subprocess.STDOUT).decode();  print(ext);  res0=re.search('.*nbcelltests.*{}.*ok'.format(nbcelltests.__version__),ext,re.IGNORECASE);  res1=re.search('nbcelltests.*enabled', ext);  sys.exit(not (res0 and res1))"
     displayName: 'Check everything was installed'
+    workingDirectory: $(Agent.TempDirectory)
 
   - script: python -m pytest --pyargs nbcelltests
     displayName: 'Run python package tests'

--- a/.azure/test-template.yml
+++ b/.azure/test-template.yml
@@ -1,0 +1,40 @@
+parameters:
+  name: ''
+  pool: ''
+
+jobs:
+- job: ${{ parameters.name }}
+  pool: ${{ parameters.pool }}
+
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '12.x'
+
+  # TODO: would prefer to specify version of celltests instead of using --pre
+  # TODO: change to some temp dir
+  - script: |
+      python -m pip install --upgrade pip
+      pip install --pre --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/packages-testing/pypi/simple/ nbcelltests --extra-index-url=https://pypi.org/simple
+      jupyter lab build
+    displayName: 'User install'
+
+  # TODO: this is make verify-install, but can't run that on win (unless we install make...)
+  - script: |
+      jupyter labextension check jupyterlab_celltests
+      python -c "import subprocess,re,sys; import nbcelltests;  ext=subprocess.check_output(['jupyter','serverextension','list'],stderr=subprocess.STDOUT).decode();  print(ext);  res0=re.search('.*nbcelltests.*{}.*ok'.format(nbcelltests.__version__),ext,re.IGNORECASE);  res1=re.search('nbcelltests.*enabled', ext);  sys.exit(not (res0 and res1))"
+    displayName: 'Check everything was installed'

--- a/.azure/test-template.yml
+++ b/.azure/test-template.yml
@@ -26,12 +26,12 @@ jobs:
       versionSpec: '12.x'
 
   # TODO: would prefer to specify version of celltests instead of using --pre
-  # TODO: change to some temp dir
   - script: |
       python -m pip install --upgrade pip
       pip install --pre --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/packages-testing/pypi/simple/ nbcelltests --extra-index-url=https://pypi.org/simple
       jupyter lab build
     displayName: 'User install'
+    workingDirectory: $(Agent.TempDirectory)
 
   # TODO: this is make verify-install, but can't run that on win (unless we install make...)
   - script: |
@@ -41,3 +41,4 @@ jobs:
 
   - script: python -m pytest --pyargs nbcelltests
     displayName: 'Run python package tests'
+    workingDirectory: $(Agent.TempDirectory)

--- a/.azure/test-template.yml
+++ b/.azure/test-template.yml
@@ -38,3 +38,6 @@ jobs:
       jupyter labextension check jupyterlab_celltests
       python -c "import subprocess,re,sys; import nbcelltests;  ext=subprocess.check_output(['jupyter','serverextension','list'],stderr=subprocess.STDOUT).decode();  print(ext);  res0=re.search('.*nbcelltests.*{}.*ok'.format(nbcelltests.__version__),ext,re.IGNORECASE);  res1=re.search('nbcelltests.*enabled', ext);  sys.exit(not (res0 and res1))"
     displayName: 'Check everything was installed'
+
+  - script: python -m pytest --pyargs nbcelltests
+    displayName: 'Run python package tests'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ To make a new release of nbcelltests:
 4. `git push upstream && git push upstream --tags v0.2.0a0` - This will push the tag you created above, which will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=packages-testing).
 5. Check the resulting packages:
     - Install and test the packages generated above in a clean environment (but which contains node.js).
-	    - See `.azure/test-template.yml` for the commands run by CI to install and test from the azure feed.
-		- There are no tests of the labextension, so run jupyterlab with a sample notebook and check you can run lint tests, run cell tests, write tests, etc.
+        - See `.azure/test-template.yml` for the commands run by CI to install and test from the azure feed.
+        - There are no tests of the labextension, so run jupyterlab with a sample notebook and check you can run lint tests, run cell tests, write tests, etc.
     - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
 6. You can upload release candidates to pypi and npm if you want:
     - pypi: `twine check /path/to/dist/* && twine upload /path/to/dist/*` (updating the path to match what you downloaded from azure).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,14 +59,9 @@ To make a new release of nbcelltests:
 3. `git tag -a v0.2.0a0 -m "Release new alpha"`
 4. `git push upstream && git push upstream --tags v0.2.0a0` - This will push the tag you created above, which will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=packages-testing).
 5. Check the resulting packages:
-    - Install and test in a clean environment:
-	    - Ensure you are not in the celltests directory (e.g. change to a temp dir).
-		- `conda create -n test_celltests020a0 python=3.7` (or equivalent if not using conda)
-        - Install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/packages-testing/pypi/simple/ nbcelltests==0.2.0a0 --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist, and to install the version you want to test.
-		- Following that, you should at least run the installed package's tests (after installing the test dependencies - see setup.py's dev dependencies): `python -m py.test --pyargs nbcelltests`.
-		- Install node.js (e.g. `conda install nodejs`).
-        - Download the nbcelltests npm package from [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=packages-testing) and then install with `jupyter labextension install /path/to/nbcelltests-0.2.0-alpha.0.tgz` (replacing the filename with whatever you downloaded).
-		- There are no tests of the labextension, so run jupyterlab with a sample notebook and check you can run lint tests, run cell tests, and write tests.
+    - Install and test the packages generated above in a clean environment (but which contains node.js).
+	    - See `.azure/test-template.yml` for the commands run by CI to install and test from the azure feed.
+		- There are no tests of the labextension, so run jupyterlab with a sample notebook and check you can run lint tests, run cell tests, write tests, etc.
     - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
 6. You can upload release candidates to pypi and npm if you want:
     - pypi: `twine check /path/to/dist/* && twine upload /path/to/dist/*` (updating the path to match what you downloaded from azure).

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Python package installation: `pip install nbcelltests`
 To use in JupyterLab, you will also need the lab and server extensions. Typically, these are
 automatically installed alongside nbcelltests, so you should not need to do anything special
 to use them. The lab extension will require a rebuild of JupyterLab, which you'll be prompted
-to do on starting JupyterLab the first time after installing celltests. Note that to use any
-lab extensions, you must have node.js installed.
+to do on starting JupyterLab the first time after installing celltests (or you can do manually
+with `jupyter lab build`. Note that you must have node.js installed (as for any lab extension).
 
 To see what extensions you have, check the output of `jupyter labextension list` (look for
 `jupyterlab_celltests`, and `jupyter serverextension list` (look for `nbcelltests`).

--- a/README.md
+++ b/README.md
@@ -15,12 +15,22 @@ Cell-by-cell testing for production Jupyter notebooks in JupyterLab
 ## Installation
 Python package installation: `pip install nbcelltests`
 
-To use in JupyterLab, you will also need the lab and server extensions:
+To use in JupyterLab, you will also need the lab and server extensions. Typically, these are
+automatically installed alongside nbcelltests, so you should not need to do anything special
+to use them. The lab extension will require a rebuild of JupyterLab, which you'll be prompted
+to do on starting JupyterLab the first time after installing celltests. Note that to use any
+lab extensions, you must have node.js installed.
+
+To see what extensions you have, check the output of `jupyter labextension list` (look for
+`jupyterlab_celltests`, and `jupyter serverextension list` (look for `nbcelltests`).
+If for some reason you need to manually install the extensions, you can do so as follows:
 
 ```bash
 jupyter labextension install jupyterlab_celltests
 jupyter serverextension enable --py nbcelltests
 ```
+
+(Note: if using in an environment, you might wish to add `--sys-prefix` to the `serverextension` command.)
 
 ## "Linearly executed notebooks?"
 When converting notebooks into html/pdf/email reports, they are executed top-to-bottom one time, and are expected to contain as little code as reasonably possible, focusing primarily on the plotting and markdown bits. Libraries for this type of thing include [Papermill](https://github.com/nteract/papermill), [JupyterLab Emails](https://github.com/timkpaine/jupyterlab_email), etc. 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ data_spec = [
     # Lab extension installed by default:
     ('share/jupyter/lab/extensions',
      'js/lab-dist',
-     'nbcelltests-*.tgz'),
+     'jupyterlab_celltests-*.tgz'),
     # Config to enable server extension by default:
     ('etc/jupyter',
      'jupyter-config',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ dev_requires = requires + [
 data_spec = [
     # Lab extension installed by default:
     ('share/jupyter/lab/extensions',
-     'lab-dist',
+     'js/lab-dist',
      'nbcelltests-*.tgz'),
     # Config to enable server extension by default:
     ('etc/jupyter',


### PR DESCRIPTION
* Fix lab extension "speculative installation"
* Add tests of "user installation" (i.e. pip install the packages that were uploaded to azure artifacts, then run the package tests and check the extensions are active).

To do:
* [x] lab extension not being included in sdist after reorg
* [x] lab extension not in wheel
* [x] update installation instructions
* [x] add tests of installed packages 
