### PR TITLE
Support disabling of one or more celltests lint rules via comment in code cell

### DIFF
--- a/nbcelltests/lint.py
+++ b/nbcelltests/lint.py
@@ -189,7 +189,6 @@ def runWithReturn(notebook, executable=None, rules=None):
     return ret
 
 
-
 def runWithHTMLReturn(notebook, executable=None, rules=None):
     ret = ''
     ret_tmp, fail = run(notebook, executable)

--- a/nbcelltests/lint.py
+++ b/nbcelltests/lint.py
@@ -184,12 +184,10 @@ def _run_and_capture_utf8(args):
     return subprocess.run(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8', **run_kw)
 
 
-# TODO: is this used? should remove, or test and fix.
 def runWithReturn(notebook, executable=None, rules=None):
     ret, fail = run(notebook)
     return ret
 
-# TODO: should be passing rules through (used by extension)
 
 
 def runWithHTMLReturn(notebook, executable=None, rules=None):

--- a/nbcelltests/tests/_lint_disable.ipynb
+++ b/nbcelltests/tests/_lint_disable.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tests": [
+     "assert x == 1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# noqa notebook: cells_per_notebook\n",
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "some markdown"
+   ],   
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "assert x == 2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 2"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "source": [
+    "raw"
+   ],   
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "assert x == 3"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = 3"
+   ]
+  }  
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/more.ipynb
+++ b/nbcelltests/tests/more.ipynb
@@ -25,6 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# LINT_DISABLE: notebook_lines_per_cell\n",
     "class X: pass"
    ]
   },

--- a/nbcelltests/tests/test_lint.py
+++ b/nbcelltests/tests/test_lint.py
@@ -124,19 +124,22 @@ def test_magics_lists_sanity():
 
 
 @pytest.mark.parametrize(
-    "rules, expected_ret, expected_pass", [
+    "rules, noqa_regex, expected_ret, expected_pass", [
         # no rules
-        ({}, [], True),
+        ({}, None, [], True),
         # one rule, pass
-        ({'lines_per_cell': -1}, [], True),
+        ({'lines_per_cell': -1}, None, [], True),
         # one rule, fail
-        ({'lines_per_cell': 1}, [LR(x, LintType.LINES_PER_CELL) for x in [False, True, False, False]], False),
+        ({'lines_per_cell': 1}, None, [LR(x, LintType.LINES_PER_CELL) for x in [False, True, False, False]], False),
         # multiple rules, combo fail
         ({'lines_per_cell': 5,
-          'cells_per_notebook': 1}, [LR(True, LintType.LINES_PER_CELL)] * 4 + [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
+          'cells_per_notebook': 1}, None, [LR(True, LintType.LINES_PER_CELL)] * 4 + [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
+        # multiple rules, one disabled, combo pass
+        ({'lines_per_cell': 1,
+          'cells_per_notebook': 10}, "# LINT_DISABLE: notebook_(.*)$", [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
         # multiple rules, combo pass
         ({'lines_per_cell': 5,
-          'cells_per_notebook': 10}, [LR(True, LintType.LINES_PER_CELL)] * 4 + [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
+          'cells_per_notebook': 10}, None, [LR(True, LintType.LINES_PER_CELL)] * 4 + [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
         # all the expected rules
         ({'lines_per_cell': 5,
           'cells_per_notebook': 2,
@@ -144,17 +147,17 @@ def test_magics_lists_sanity():
           'class_definitions': 0,
           'kernelspec_requirements':
             {'name': 'python3'},
-          'magics_whitelist': ['matplotlib']}, [LR(True, LintType.LINES_PER_CELL)] * 4 +
-                                               [LR(False, LintType.CELLS_PER_NOTEBOOK)] +
-                                               [LR(False, LintType.FUNCTION_DEFINITIONS)] +
-                                               [LR(False, LintType.CLASS_DEFINITIONS)] +
-                                               [LR(True, LintType.KERNELSPEC)] +
-                                               [LR(True, LintType.MAGICS)], False)
+          'magics_whitelist': ['matplotlib']}, None, [LR(True, LintType.LINES_PER_CELL)] * 4 +
+                                                     [LR(False, LintType.CELLS_PER_NOTEBOOK)] +
+                                                     [LR(False, LintType.FUNCTION_DEFINITIONS)] +
+                                                     [LR(False, LintType.CLASS_DEFINITIONS)] +
+                                                     [LR(True, LintType.KERNELSPEC)] +
+                                                     [LR(True, LintType.MAGICS)], False)
     ]
 )
-def test_run(rules, expected_ret, expected_pass):
+def test_run(rules, noqa_regex, expected_ret, expected_pass):
     nb = os.path.join(os.path.dirname(__file__), 'more.ipynb')
-    ret, passed = run(nb, rules=rules)
+    ret, passed = run(nb, rules=rules, noqa_regex=noqa_regex)
     _verify(ret, passed, expected_ret, expected_pass)
 
 

--- a/nbcelltests/tests/test_shared.py
+++ b/nbcelltests/tests/test_shared.py
@@ -17,6 +17,7 @@ BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
 MORE_NB = os.path.join(os.path.dirname(__file__), 'more.ipynb')
 MAGICS_NB = os.path.join(os.path.dirname(__file__), 'magics.ipynb')
 COVERAGE_NB = os.path.join(os.path.dirname(__file__), '_cell_coverage.ipynb')
+LINT_DISABLE_NB = os.path.join(os.path.dirname(__file__), '_lint_disable.ipynb')
 
 
 def test_is_empty():
@@ -139,3 +140,29 @@ def test_get_coverage(test_count, cell_count, expected):
         'cell_count': cell_count
     }
     assert get_coverage(metadata) == expected
+
+
+# lint disable
+
+def test_extract_extrametadata_disable_none():
+    metadata = extract_extrametadata(nbformat.read(LINT_DISABLE_NB, 4))
+    assert len(metadata['noqa']) == 0
+
+
+def test_extract_extrametadata_disable_notpresent():
+    metadata = extract_extrametadata(nbformat.read(LINT_DISABLE_NB, 4), noqa_regex=r"^# don't noqa notebook:\s*(.*)$")
+    assert len(metadata['noqa']) == 0
+
+
+def test_extract_extrametadata_disable_cells_count():
+    metadata = extract_extrametadata(nbformat.read(LINT_DISABLE_NB, 4), noqa_regex=r"^# noqa notebook:\s*(.*)$")
+    assert metadata['noqa'] == {'cells_per_notebook'}
+
+
+def test_extract_extrametadata_disable_bad_regex():
+    try:
+        metadata = extract_extrametadata(nbformat.read(LINT_DISABLE_NB, 4), noqa_regex=r"^# noqa notebook:\s*.*$")
+    except ValueError as e:
+        assert e.args[0] == "noqa_regex must contain one capture group (specifying the rule)"
+    else:
+        assert False, "should have raised a ValueError"


### PR DESCRIPTION
One way of doing #141 

~~Note: base branch should be updated to master once #144 is merged (i.e. this depends on #144).~~

I'm not sure I like disabling rules such as number of cells per notebook via a comment in a code cell, but this might allow someone to integrate with a pre-existing system that already uses such comments for python code.

For instance, if you already had a system that allowed for disabling lint rules in python code e.g. via a `# STATIC_CHECK_DISABLE rulename` comment, and that system counted such comments as part of a static check score, and your notebooks were already going through such a system, then this might help you.

The `# STATIC_CHECK_DISABLE` part is just a regex, so can be anything.

Example use: 
* the system currently does `nbcelltests.lint.run(notebook, rules={'cells_per_notebook': 999})`
* a notebook author has one notebook that fails lint because it contains 1000 cells
* you change the system call to `nbcelltests.lint.run(notebook, rules={'cells_per_notebook': 999}), noqa_regex="^# STATIC_CHECK_DISABLE (.*)$")`
* the notebook author can add `# STATIC_CHECK_DISABLE cells_per_notebook` as a comment at the start of a line in a cell, and the number of cells will not be checked.

