### PR TITLE
Make lint.runWithHTMLReturn() respect supplied rules

### DIFF
--- a/nbcelltests/lint.py
+++ b/nbcelltests/lint.py
@@ -158,11 +158,6 @@ def _run_and_capture_utf8(args):
     return subprocess.run(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8', **run_kw)
 
 
-def runWithReturn(notebook, executable=None, rules=None):
-    ret, fail = run(notebook)
-    return ret
-
-
 def runWithHTMLReturn(notebook, executable=None, rules=None):
     ret = ''
     ret_tmp, fail = run(notebook, executable=executable, rules=rules)

--- a/nbcelltests/lint.py
+++ b/nbcelltests/lint.py
@@ -165,7 +165,7 @@ def runWithReturn(notebook, executable=None, rules=None):
 
 def runWithHTMLReturn(notebook, executable=None, rules=None):
     ret = ''
-    ret_tmp, fail = run(notebook, executable)
+    ret_tmp, fail = run(notebook, executable=executable, rules=rules)
     for lint in ret_tmp:
         lint = lint.to_html()
         ret += '<p>' + lint + '</p>'


### PR DESCRIPTION
Fixes #143 