### PR TITLE
Fix testing of "user installation testing"

### DIFF
--- a/.azure/test-template.yml
+++ b/.azure/test-template.yml
@@ -26,8 +26,9 @@ jobs:
       versionSpec: '12.x'
 
   # TODO: would prefer to specify version of celltests instead of using --pre
+  # (since with --pre we're potentially getting pre-releases of deps too).
   # Should be able to get version from somewhere (e.g. python setup.py --version,
-  # git tag, or whatever)
+  # git tag, or whatever) and use it below as nbcelltests==version
   - script: |
       python -m pip install --upgrade pip
       pip install --pre --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/packages-testing/pypi/simple/ nbcelltests --extra-index-url=https://pypi.org/simple

--- a/.azure/test-template.yml
+++ b/.azure/test-template.yml
@@ -26,6 +26,8 @@ jobs:
       versionSpec: '12.x'
 
   # TODO: would prefer to specify version of celltests instead of using --pre
+  # Should be able to get version from somewhere (e.g. python setup.py --version,
+  # git tag, or whatever)
   - script: |
       python -m pip install --upgrade pip
       pip install --pre --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/packages-testing/pypi/simple/ nbcelltests --extra-index-url=https://pypi.org/simple
@@ -39,6 +41,14 @@ jobs:
       python -c "import subprocess,re,sys; import nbcelltests;  ext=subprocess.check_output(['jupyter','serverextension','list'],stderr=subprocess.STDOUT).decode();  print(ext);  res0=re.search('.*nbcelltests.*{}.*ok'.format(nbcelltests.__version__),ext,re.IGNORECASE);  res1=re.search('nbcelltests.*enabled', ext);  sys.exit(not (res0 and res1))"
     displayName: 'Check everything was installed'
     workingDirectory: $(Agent.TempDirectory)
+
+  - script: |
+      # could use dephell to add just test deps, but don't want dephell in test env, and don't know how to use envs on azure yet.
+      #python -m pip install dephell[all]
+      #dephell deps convert --from=setup.py --to=requirements.txt --envs=test
+      #python -m pip install -r requirements.txt
+      pip install --pre --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/packages-testing/pypi/simple/ nbcelltests[dev] --extra-index-url=https://pypi.org/simple
+    displayName: 'Install test deps'
 
   - script: python -m pytest --pyargs nbcelltests
     displayName: 'Run python package tests'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,20 +52,25 @@ Once you have such a development setup, you should:
 
 # Releasing
 
-To make a new release of nbcelltests:
+To make a new release of nbcelltests from a fork, you can follow the
+procedure below to have package building and testing occur on neutral
+CI machines across multiple platforms. This is best viewed as a
+somewhat asynchronous process, during which you'll likely want to be
+working on other things. If you are further from release and want to
+iterate faster, you can of course use local commands and environments
+to build and test packages (see the Makefile, e.g. `make dist`).
 
 1. Assuming `jpmorgan/celltests` is `upstream` (note: package uploads to azure feed not possible from forks).
-2. The version in `.bumpversion.cfg` should already be something like `(0, 2, 0, 'alpha', 0)` or similar (i.e. some pre-release version that is ahead of the most recent version at pypi). If not, you should increment: `bumpversion patch` (replace `patch` with whatever is appropriate for the current release, e.g. `minor`, `major`, etc) - This will also create a git commit (but not a tag). Say the version is now `(0, 2, 0, 'alpha', 0)`.
-3. `git tag -a v0.2.0a0 -m "Release new alpha"`
-4. `git push upstream && git push upstream --tags v0.2.0a0` - This will push the tag you created above, which will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=packages-testing).
-5. Check the resulting packages:
-    - Install and test the packages generated above in a clean environment (but which contains node.js).
+2. The version in `.bumpversion.cfg` should already be something like `(0, 2, 0, 'alpha', 0)` or similar (i.e. some pre-release version that is ahead of the most recent version at pypi). If not, you should increment: `bumpversion patch` (replace `patch` with whatever is appropriate for the current release, e.g. `minor`, `major`, etc) - This will also create a git commit (but not a tag). You will need to do this in your fork, then open a PR and get it approved and merged. Say the version is now `(0, 2, 0, 'alpha', 0)`. 
+3. After your PR is merged, update your fork, and then `git tag -a v0.2.0a0 -m "Release new alpha"` followed by `git push upstream --tags v0.2.0a0` - Pushing the tag will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=packages-testing).
+4. Assuming packages were built and tested successfully on azure, you should then manually check the resulting packages:
+    - Install and test the packages generated above in a clean environment (containing python and node.js).
         - See `.azure/test-template.yml` for the commands run by CI to install and test from the azure feed.
         - There are no tests of the labextension, so run jupyterlab with a sample notebook and check you can run lint tests, run cell tests, write tests, etc.
     - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
-6. You can upload release candidates to pypi and npm if you want:
+5. You can upload release candidates to pypi and npm if you want to do an extra check:
     - pypi: `twine check /path/to/dist/* && twine upload /path/to/dist/*` (updating the path to match what you downloaded from azure).
     - npm: `npm publish --tag beta /path/to/nbcelltests-0.2.0-alpha.0.tgz` (updating the filename to match what you downloaded from azure).
-7. If there's a problem with the packages, fix the issue, then go back to step 2.
-8. Once satisfied, use `bumpversion` either to set or increment `release` to `final` (e.g.  `bumpversion release`), and then repeat steps 3 and 4. Grab the resulting releases from azure and upload to pypi and npm.
-9. At some point (?) after the release, bump the version to (?).
+6. If there's a problem with the packages, fix the issue, then go back to step 2.
+7. Once satisfied with the packages, repeat steps 2 and 3, using `bumpversion` in step 2 either to set or increment `release` to `final` (e.g.  `bumpversion release`). Grab the resulting releases from azure and upload to pypi and npm.
+8. At some point (?) after the release, bump the version to (?).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cell-by-cell testing for production Jupyter notebooks in JupyterLab
 [![Docs](https://img.shields.io/readthedocs/nbcelltests.svg)](https://nbcelltests.readthedocs.io)
 [![PyPI](https://img.shields.io/pypi/l/nbcelltests.svg)](https://pypi.python.org/pypi/nbcelltests)
 [![PyPI](https://img.shields.io/pypi/v/nbcelltests.svg)](https://pypi.python.org/pypi/nbcelltests)
-[![npm](https://img.shields.io/npm/v/nbcelltests.svg)](https://www.npmjs.com/package/nbcelltests)
+[![npm](https://img.shields.io/npm/v/jupyterlab_celltests.svg)](https://www.npmjs.com/package/jupyterlab_celltests)
 
 
 # Overview


### PR DESCRIPTION
Needed to install test deps before testing installed package.

Note that pip installing the 0.2.0a2 package (plus doing a jupyter lab build) does result in extensions being successfully active (I ran the changes here in isolation to check):

![Screenshot from 2020-05-27 23-39-32](https://user-images.githubusercontent.com/1929/83079628-2673df80-a074-11ea-859d-33ea4104249c.png)


Also: 
  * Fixed link to npm package (jupyterlab_celltests, not nbcelltests).
  * Added clarification to release procedure. Mainly that the procedure described has package building and testing occur on neutral CI machines across multiple platforms, and is best viewed as a somewhat asynchronous process, during which you'll likely want to be working on other things :) But if you want to iterate faster, you can of course still use local commands and environments to build and test packages.