### PR TITLE
Copy license and readme into npm package.

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf lib",
     "fix": "eslint -c .eslintrc.js --ext .ts --fix src/ tests/",
     "lint": "eslint -c .eslintrc.js --ext .ts src/ tests/",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "cpx ../README.md . && cpx ../LICENSE . && npm run build",
     "test": "jest --coverage --collectCoverageFrom=src/*.{ts}"
   },
   "files": [
@@ -59,6 +59,7 @@
     "@typescript-eslint/eslint-plugin-tslint": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "babel-jest": "^24.8.0",
+    "cpx": "^1.5.0",  
     "eslint": "^7.0.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsdoc": "^25.4.2",


### PR DESCRIPTION
Fixes #159 (see comments there)

Tried locally on linux:
```
$ npm publish --dry-run

> jupyterlab_celltests@0.2.0 prepublishOnly .
> cpx ../README.md . && cpx ../LICENSE . && npm run build


> jupyterlab_celltests@0.2.0 build /home/sefkw/code/jpmorganchase/nbcelltests/js
> tsc

npm notice 
npm notice 📦  jupyterlab_celltests@0.2.0
npm notice === Tarball Contents === 
npm notice 11.4kB LICENSE          
npm notice 1.5kB  style/index.css  
npm notice 1.4kB  lib/activate.js  
npm notice 840B   lib/index.js     
npm notice 4.5kB  lib/run.js       
npm notice 1.9kB  lib/tool.js      
npm notice 1.1kB  lib/utils.js     
npm notice 13.2kB lib/widget.js    
npm notice 2.4kB  package.json     
npm notice 7.0kB  README.md        
npm notice 717B   lib/activate.d.ts
npm notice 545B   lib/index.d.ts   
npm notice 608B   lib/run.d.ts     
npm notice 1.1kB  lib/tool.d.ts    
npm notice 1.1kB  lib/utils.d.ts   
npm notice 1.1kB  lib/widget.d.ts  
npm notice === Tarball Details === 
npm notice name:          jupyterlab_celltests                    
npm notice version:       0.2.0                                   
npm notice package size:  12.6 kB                                 
npm notice unpacked size: 50.2 kB                                 
npm notice shasum:        8517792d9a9f5772d913accad76851e6a2267305
npm notice integrity:     sha512-CzZpSAmwHt0mq[...]aFdLCRWAEzyag==
npm notice total files:   16                                      
npm notice 
+ jupyterlab_celltests@0.2.0
```