### PR TITLE
If a test is skipped, its corresponding cell should still be available for execution by any subsequent tests

### DIFF
--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -57,8 +57,8 @@ def assemble_code(notebook):
         cells.append([code_cell, [], "%sdef test_code_cell_%d(self):\n" % (skiptest, code_cell)])
 
         if skiptest:
-            cells[-1][1].append(INDENT + 'pass # code cell %d was skipped\n' % code_cell)
-            continue
+            # still need the cell to be present for any subsequent tests to execute
+            test_lines = ["%cell"]
 
         for test_line in test_lines:
             if test_line.strip().startswith(r"%cell"):

--- a/nbcelltests/tests/_skips.ipynb
+++ b/nbcelltests/tests/_skips.ipynb
@@ -65,7 +65,22 @@
    "source": [
     "x = 1"
    ]
-  }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tests": [
+     "%cell\n",
+     "assert y==1\n",
+     "assert x==1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "y = 1"
+   ]
+  }  
  ],
  "metadata": {
   "kernelspec": {

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -170,6 +170,14 @@ class TestSkips(_TestCellTests):
         """Test+cell where test does not inject cell should be skipped"""
         self._assert_skipped(self.t.test_code_cell_6, "cell code not injected into test")
 
+    def test_if_test_is_skipped_cell_should_still_be_run_for_subsequent_tests(self):
+        """Previous tests were skipped, but cells should execute for this test"""
+        self.t.test_code_cell_7()
+        self.t._run("assert x == 1, x")
+        self.t.tearDown()
+        if FORKED:
+            self.t.tearDownClass()
+
 
 class TestCumulativeRun(_TestCellTests):
     """Tests that state in notebook is built up correctly."""

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -174,9 +174,6 @@ class TestSkips(_TestCellTests):
         """Previous tests were skipped, but cells should execute for this test"""
         self.t.test_code_cell_7()
         self.t._run("assert x == 1, x")
-        self.t.tearDown()
-        if FORKED:
-            self.t.tearDownClass()
 
 
 class TestCumulativeRun(_TestCellTests):


### PR DESCRIPTION
Fixes #165 