### PR TITLE
Get notebook source at run time; don't store notebook code in generated script.

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -59,7 +59,7 @@
     "@typescript-eslint/eslint-plugin-tslint": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "babel-jest": "^24.8.0",
-    "cpx": "^1.5.0",  
+    "cpx": "^1.5.0",
     "eslint": "^7.0.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsdoc": "^25.4.2",

--- a/nbcelltests/shared.py
+++ b/nbcelltests/shared.py
@@ -127,7 +127,7 @@ def extract_extrametadata(notebook, override=None, noqa_regex=None):
             if not is_empty(line):
                 base['lines'] += 1
                 base['cell_lines'][-1] += 1
-        if cell_injected_into_test(c['metadata'].get('tests', [])):
+        if cell_injected_into_test(get_test(c)):
             base['test_count'] += 1
             base['cell_tested'][-1] = True
 
@@ -136,6 +136,10 @@ def extract_extrametadata(notebook, override=None, noqa_regex=None):
         base.update(override)
 
     return base
+
+
+def get_test(cell):
+    return lines2source(cell.get('metadata', {}).get('tests', []))
 
 
 def is_empty(source):
@@ -152,9 +156,29 @@ def is_empty(source):
     return len(parsed.body) == 0
 
 
-def cell_injected_into_test(test_lines):
-    for test_line in test_lines:
-        if test_line.strip().startswith(r"%cell"):
+CELL_INJ_TOKEN = r"%cell"
+
+
+def source2lines(source):
+    return source.splitlines(keepends=True)
+
+
+def lines2source(lines):
+    return "".join(lines)
+
+
+def cell_inj_span(test_line):
+    if not test_line.strip().startswith(CELL_INJ_TOKEN):
+        return None
+    else:
+        cell_start = test_line.index(CELL_INJ_TOKEN)
+        cell_end = cell_start + len(CELL_INJ_TOKEN)
+        return cell_start, cell_end
+
+
+def cell_injected_into_test(test_source):
+    for test_line in source2lines(test_source):
+        if cell_inj_span(test_line) is not None:
             return True
     return False
 

--- a/nbcelltests/shared.py
+++ b/nbcelltests/shared.py
@@ -167,7 +167,11 @@ def lines2source(lines):
     return "".join(lines)
 
 
-def cell_inj_span(test_line):
+def get_cell_inj_span(test_line):
+    """
+    Return the location of %cell in the given line as (start_index,
+    end_index), or None if %cell does not occur.
+    """
     if not test_line.strip().startswith(CELL_INJ_TOKEN):
         return None
     else:
@@ -178,7 +182,7 @@ def cell_inj_span(test_line):
 
 def cell_injected_into_test(test_source):
     for test_line in source2lines(test_source):
-        if cell_inj_span(test_line) is not None:
+        if get_cell_inj_span(test_line) is not None:
             return True
     return False
 

--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -25,6 +25,10 @@ def run(notebook, rules=None, filename=None, override_kernel_name=""):
     rules = rules or {}
     extra_metadata.update(rules)
 
+    # TODO: Coverage shouldn't be recorded at generation time as it
+    # will go stale if the notebook changes. Should move to same
+    # mechanism as source/tests. However, we plan to replace coverage
+    # with code coverage measured during test execution.
     coverage = []
     if 'cell_coverage' in extra_metadata:
         coverage.append((get_coverage(extra_metadata), extra_metadata['cell_coverage']))

--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -13,120 +13,25 @@ import sys
 import subprocess
 import tempfile
 from .define import TestMessage, TestType
-from .shared import extract_extrametadata, get_coverage, is_empty, cell_injected_into_test
+from .shared import extract_extrametadata, get_coverage
 from .tests_vendored import BASE, JSON_CONFD
 
-# TODO: eventually want assemble() and the rest to be doing something
-# better than building up code in strings. It's tricky to work with,
-# tricky to read, can't lint, can't test easily, unlikely to be
-# generally correct, etc etc :)
 
-# TODO: there are multiple definitions of "is tested", "is code cell"
-# throughout the code.
-
-INDENT = '    '
-
-
-def assemble_code(notebook):
-    cells = []
-    code_cell = 0
-    # notes:
-    #   * code cell counting is 1 based
-    #   * the only import in the template is nbcelltests.tests_vendored
-    for i, cell in enumerate(notebook.cells, start=1):
-        # TODO: duplicate definition how to get tests
-        test_lines = cell.get('metadata', {}).get('tests', [])
-
-        if cell.get('cell_type') != 'code':
-            if len(test_lines) > 0:
-                raise ValueError("Cell %d is not a code cell, but metadata contains test code!" % i)
-            continue
-
-        code_cell += 1
-
-        if is_empty(cell['source']):
-            skiptest = "@nbcelltests.tests_vendored.unittest.skip('empty code cell')\n" + INDENT
-        elif is_empty("".join(test_lines).replace(r"%cell", "pass # no test was supplied")):
-            skiptest = "@nbcelltests.tests_vendored.unittest.skip('no test supplied')\n" + INDENT
-        elif not cell_injected_into_test(test_lines):
-            skiptest = "@nbcelltests.tests_vendored.unittest.skip('cell code not injected into test')\n" + INDENT
-        else:
-            skiptest = ""
-
-        # TODO: Use namedtuples for these:
-        cells.append([code_cell, [], "%sdef test_code_cell_%d(self):\n" % (skiptest, code_cell)])
-
-        if skiptest:
-            cells[-1][1].append(INDENT + 'pass # code cell %d was skipped\n' % code_cell)
-            continue
-
-        for test_line in test_lines:
-            if test_line.strip().startswith(r"%cell"):
-                # add comment in test for readability
-                cells[-1][1].append(INDENT + test_line.replace(r'%cell', '# Cell {' + str(code_cell) + '} content\n'))
-
-                # add all code for cell
-                for cell_line in cell['source'].split('\n'):
-                    # TODO: is this going to replace %cell appearing in a comment?
-                    cells[-1][1].append(INDENT + test_line.replace('\n', '').replace(r'%cell', '') + cell_line + '\n')
-
-            # else just write test
-            else:
-                cells[-1][1].append(INDENT + test_line)
-                if not test_line[-1] == '\n':
-                    cells[-1][1][-1] += '\n'
-    return cells
-
-
-def writeout_test(fp, cells, kernel_name):
-    fp.write(BASE.format(kernel_name=kernel_name))
-
-    # write out source of cells+tests
-    fp.write(INDENT + "cells_and_tests = {")
-    for i, code, _ in cells:
-        fp.write('\n')
-        fp.write(INDENT * 2 + '%d: """\n' % i)
-        for line in code:
-            fp.write(INDENT + line)
-        fp.write(INDENT * 2 + '""",\n')
-    fp.write(INDENT + "}\n")
-
-    # write out test methods
-    for i, _, meth in cells:
-        fp.write('\n')
-        fp.write(INDENT + meth)
-        fp.write(INDENT * 2 + 'self.run_test(%d)\n' % i)
-
-
-def writeout_cell_coverage(fp, cell_coverage, metadata):
-    if cell_coverage:
-        fp.write(INDENT + 'def test_cell_coverage(self):\n')
-        fp.write(
-            2 *
-            INDENT +
-            'assert {cells_covered} >= {limit}, "Actual cell coverage {cells_covered} < minimum required of {limit}"\n\n'.format(
-                limit=cell_coverage,
-                cells_covered=get_coverage(metadata)))
-
-
-def run(notebook, rules=None, filename=None):
+def run(notebook, rules=None, filename=None, override_kernel_name=""):
     """Runs no tests: just generates test script for supplied notebook."""
     nb = nbformat.read(notebook, 4)
-    name = filename or notebook[:-6] + '_test.py'  # remove .ipynb, replace with _test.py
-
-    kernel_name = nb.metadata.get('kernelspec', {}).get('name', 'python')
-    cells = assemble_code(nb)
+    name = filename or notebook[:-6] + '_test.py'
     extra_metadata = extract_extrametadata(nb)
     rules = rules or {}
     extra_metadata.update(rules)
 
+    coverage = []
+    if 'cell_coverage' in extra_metadata:
+        coverage.append((get_coverage(extra_metadata), extra_metadata['cell_coverage']))
+
     # output tests to test file
     with open(name, 'w', encoding='utf-8') as fp:
-        writeout_test(fp, cells, kernel_name)
-
-        if 'cell_coverage' in extra_metadata:
-            cell_coverage = extra_metadata['cell_coverage']
-            writeout_cell_coverage(fp, cell_coverage, extra_metadata)
+        fp.write(BASE.format(override_kernel_name=override_kernel_name, path_to_notebook=notebook, coverage=coverage))
 
     return name
 

--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -20,7 +20,7 @@ from .tests_vendored import BASE, JSON_CONFD
 def run(notebook, rules=None, filename=None, override_kernel_name=""):
     """Runs no tests: just generates test script for supplied notebook."""
     nb = nbformat.read(notebook, 4)
-    name = filename or notebook[:-6] + '_test.py'
+    name = filename or os.path.splitext(notebook)[0] + '_test.py'
     extra_metadata = extract_extrametadata(nb)
     rules = rules or {}
     extra_metadata.update(rules)

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -62,7 +62,7 @@ from nbcelltests.shared import is_empty, cell_injected_into_test, source2lines, 
 
 def get_kernel(path_to_notebook):
     notebook = nbformat.read(path_to_notebook, 4)
-    # TODO don't default like this here
+    # TODO don't default kernel like this here (address as part of https://github.com/jpmorganchase/nbcelltests/issues/164)
     return notebook['metadata'].get('kernelspec', {}).get('name', 'python')
 
 

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -319,8 +319,8 @@ BASE = '''
 from parameterized import parameterized
 from nbcelltests.tests_vendored import TestNotebookBase, get_celltests, get_kernel, generate_name
 
-_celltests = get_celltests("{path_to_notebook}")
-_kernel_name = get_kernel("{path_to_notebook}")
+_celltests = get_celltests(r"{path_to_notebook}")
+_kernel_name = get_kernel(r"{path_to_notebook}")
 
 class TestNotebook(TestNotebookBase):
     KERNEL_NAME = "{override_kernel_name}" or _kernel_name

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -76,12 +76,12 @@ def _inject_cell_into_test(cell_source, test_source):
     whitespace as %cell.
 
     Example:
- 
+
       test:
         if x > 0:
             %cell # end of %cell
         assert x == 10
-        assert z == 15 
+        assert z == 15
 
       cell:
         x*=5

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -54,7 +54,115 @@ except ImportError:
 
 import unittest
 
+import nbformat
 from nbval.kernel import RunningKernel
+
+from nbcelltests.shared import is_empty, cell_injected_into_test, source2lines, lines2source, cell_inj_span, get_test
+
+
+def get_kernel(path_to_notebook):
+    notebook = nbformat.read(path_to_notebook, 4)
+    # TODO don't default like this here
+    return notebook['metadata'].get('kernelspec', {}).get('name', 'python')
+
+
+def _inject_cell_into_test(cell_source, test_source):
+    """Inserts cell_source into test.
+
+    The cell_source is inserted wherever %cell appears at the stripped
+    start of a line.
+
+    All lines of cell_source are prefixed with the same leading
+    whitespace as %cell.
+
+    Example:
+ 
+      test:
+        if x > 0:
+            %cell # end of %cell
+        assert x == 10
+        assert z == 15 
+
+      cell:
+        x*=5
+        z = x + \
+            5
+        print(x)
+
+      celltest:
+        if x > 0:
+            x*=5
+            z = x + \
+                5
+            print(x) # end of %cell
+        assert x == 10
+        assert z == 15
+    """
+    celltest_lines = []
+    for test_line in source2lines(test_source):
+        cell_span = cell_inj_span(test_line)
+        if cell_span is not None:
+            prefix = test_line[0:cell_span[0]]
+            for cell_line in source2lines(cell_source):
+                celltest_lines.append(prefix + cell_line)
+
+            suffix = test_line[cell_span[1]::]
+            if len(suffix) > 0:
+                if len(celltest_lines) == 0:
+                    celltest_lines.append('')
+                celltest_lines[-1] += suffix
+        else:
+            celltest_lines.append(test_line)
+    return lines2source(celltest_lines)
+
+
+def get_celltests(path_to_notebook):
+    """
+    Return a dictionary of {code cell number: celltest} for all the code
+    cells in the given notebook.
+
+    A celltest is a source code string of the test supplied for a
+    cell, plus the cell itself wherever (if) injected into the test
+    using %cell.
+
+    (celltest is actually currently a dictionary of skip_reason (if any)
+    and the source code, but we're unsure if we want to keep the skipping
+    part. If keeping, we'll need to clean up and doc.)
+    """
+    notebook = nbformat.read(path_to_notebook, 4)
+    celltests = {}
+    code_cell = 0
+    for i, cell in enumerate(notebook.cells, start=1):
+        test_source = lines2source(get_test(cell))
+        empty_test = is_empty(_inject_cell_into_test("pass", test_source))
+
+        if cell.get('cell_type') != 'code':
+            if not empty_test:
+                raise ValueError("Cell %d is not a code cell, but metadata contains test code!" % i)
+            continue
+
+        code_cell += 1
+        celltest = _inject_cell_into_test(cell['source'], test_source)
+
+        # TODO: we are unsure if we want to keep the skipping part!
+        # If keeping, clean up and document above.
+        skip_reason = None
+        if is_empty(cell['source']):
+            skip_reason = "empty code cell"
+        elif empty_test:
+            skip_reason = "no test supplied"
+        elif not cell_injected_into_test(test_source):
+            skip_reason = "cell code not injected into test"
+
+        celltests[code_cell] = {'skip_reason': skip_reason,
+                                'source': celltest if not skip_reason else ""}
+
+    return celltests
+
+
+def generate_name(testcase_func, param_num, param):
+    """Used to generate parameterized method names like test_code_cell_n"""
+    return "test_code_cell_%s" % param.args[0]
 
 
 class TestNotebookBase(unittest.TestCase):
@@ -100,29 +208,32 @@ class TestNotebookBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kernel = RunningKernel(cls.KERNEL_NAME)
-        cls.cells_run = set()
+        cls.celltests_run = set()
 
     @classmethod
     def tearDownClass(cls):
         cls.kernel.stop()
+
+    def assert_coverage(self, cells_covered, min_required):
+        assert cells_covered >= min_required, "Actual cell coverage %s < minimum required of %s" % (cells_covered, min_required)
 
     def run_test(self, cell):
         """
         Run any cells preceding cell (number) that have not already been
         run, then run cell itself.
         """
-        # maybe do some assertions that we didn't get all messed up
-        # with missing cells etc
+        if self.celltests[cell]['skip_reason']:
+            raise unittest.SkipTest(self.celltests[cell]['skip_reason'])
+
         preceding_cells = set(range(1, cell))
-        for preceding_cell in sorted(set(preceding_cells) - self.cells_run):
+        for preceding_cell in sorted(set(preceding_cells) - self.celltests_run):
             self._run_cell(preceding_cell)
         self._run_cell(cell)
 
     def _run_cell(self, cell):
-        # convenience method
-        self._run(self.cells_and_tests[cell], "Running cell+test for code cell %d" % cell)
-        # will only add if there was no error running
-        self.cells_run.add(cell)
+        """Run cell and record its execution"""
+        self._run(self.celltests[cell]["source"], "Running cell+test for code cell %d" % cell)
+        self.celltests_run.add(cell)
 
     def _run(self, cell_content, description=''):
         """
@@ -200,12 +311,28 @@ class TestNotebookBase(unittest.TestCase):
         # End of code from nbval
 
 
+# Fetches notebook source at import time. Don't necessarily think we
+# should do the dynamic test generation this way; first priority was
+# just to clean up so code's not built up in string.
+
 BASE = '''
-import nbcelltests.tests_vendored
+from parameterized import parameterized
+from nbcelltests.tests_vendored import TestNotebookBase, get_celltests, get_kernel, generate_name
 
-class TestNotebook(nbcelltests.tests_vendored.TestNotebookBase):
-    KERNEL_NAME = "{kernel_name}"
+_celltests = get_celltests("{path_to_notebook}")
+_kernel_name = get_kernel("{path_to_notebook}")
 
+class TestNotebook(TestNotebookBase):
+    KERNEL_NAME = "{override_kernel_name}" or _kernel_name
+    celltests = _celltests
+
+    @parameterized.expand([(i,) for i in _celltests], name_func=generate_name)
+    def _test_code_cell(self, cell_num):
+        self.run_test(cell_num)
+
+    @parameterized.expand({coverage}, skip_on_empty=True, name_func=lambda *args: "test_cell_coverage")
+    def _test_coverage(self, actual,required):
+        self.assert_coverage(actual,required)
 '''
 
 JSON_CONFD = '''

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -57,7 +57,7 @@ import unittest
 import nbformat
 from nbval.kernel import RunningKernel
 
-from nbcelltests.shared import is_empty, cell_injected_into_test, source2lines, lines2source, cell_inj_span, get_test
+from nbcelltests.shared import is_empty, cell_injected_into_test, source2lines, lines2source, get_cell_inj_span, get_test
 
 
 def get_kernel(path_to_notebook):
@@ -100,13 +100,13 @@ def _inject_cell_into_test(cell_source, test_source):
     """
     celltest_lines = []
     for test_line in source2lines(test_source):
-        cell_span = cell_inj_span(test_line)
-        if cell_span is not None:
-            prefix = test_line[0:cell_span[0]]
+        cell_inj_span = get_cell_inj_span(test_line)
+        if cell_inj_span is not None:
+            prefix = test_line[0:cell_inj_span[0]]
             for cell_line in source2lines(cell_source):
                 celltest_lines.append(prefix + cell_line)
 
-            suffix = test_line[cell_span[1]::]
+            suffix = test_line[cell_inj_span[1]::]
             if len(suffix) > 0:
                 if len(celltest_lines) == 0:
                     celltest_lines.append('')

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requires = [
     'pytest-cov',
     'pytest-html>=1.20.0',
     'flake8',
+    'parameterized',
 ]
 
 dev_requires = requires + [


### PR DESCRIPTION
Rather than "dumping the source code from the notebook as a string into the generated test script string", the generated test script now reads the source code from the notebook when the test script is *run*. This means the generated test script will no longer become out of sync with the notebook.

However, that is not the primary motivation of this PR :) The primary motivation is to move celltest assembly out of a "gradually built up string" and into real source code.

It would be possible to decouple the two changes above, but it was easier to do them together. I would be ok with separating, though, if we agree on a way to storing the notebook's source code in a python script in a way it can be submitted to the kernel.

Notes:

* We are not at the desired end state yet; apart from getting the notebook cell source and tests "at generated script run time" rather than generation time, this PR does not change the current behavior behavior (except bug fixes as noted below). PR(s) to subsequently change behavior will be easier to make and review after this change.

* I picked one way to do dynamic test method generation (using parameterized), but it could be done in a variety of other ways.

## Main changes

* Move celltest assembly/construction out of "gradually built up string" and into real source code.

* Get cell source and tests at generated script runtime rather than at generation time.

## Smaller changes

* Internal: Just one definition of various concepts (%cell, getting test for cell, moving between source string/lines)

* Fix injection of cell into test (fixes #162).

* Introduce concept of kernel name override (not used yet; will enable #164).

* Tests: fix tests of skipping (now actually runs the tests and checks they skip).

* Tests: fix tests of problematic input (the tests were previously failing before the assertions, since the previous assemble() method was generating code containing syntax errors. I verified the fixed tests fail on master.
