### PR TITLE
Celltest always generated for non-empty code cell, and always runs; defaults to %cell if test is empty

### DIFF
--- a/js/src/widget.ts
+++ b/js/src/widget.ts
@@ -273,7 +273,7 @@ export class CelltestsWidget extends Widget {
       let tests = this.currentActiveCell.model.metadata.get("tests") as string[];
       let s = "";
       if (tests === undefined || tests.length === 0) {
-        tests = ["# Use %cell to execute the cell\n"];
+        tests = ["# Use %cell to mark where the cell should be inserted, or add a line comment \"# no %cell\" to deliberately skip the cell\n", "%cell\n"];
       }
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
       for (let i = 0; i < tests.length; i++) {

--- a/nbcelltests/shared.py
+++ b/nbcelltests/shared.py
@@ -226,7 +226,7 @@ def cell_injected_into_test(test_source):
             run = False
 
     if run is False and inject:
-        raise ValueError("'%s' and '%s' are mutually exclusive but both were supplied:\n%s" % (CELL_SKIP_TOKEN, CELL_INJ_SPAN, test_source))
+        raise ValueError("'%s' and '%s' are mutually exclusive but both were supplied:\n%s" % (CELL_SKIP_TOKEN, CELL_INJ_TOKEN, test_source))
 
     return inject or run
 

--- a/nbcelltests/tests/_broken_magics.ipynb
+++ b/nbcelltests/tests/_broken_magics.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%magics2\n",
+    "raise\n",
+    "class X: pass"
+   ]
+  }      
+ ],
+ "metadata": {
+  "celltests": {
+   "cell_coverage": 50
+  }, 
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_cell_counting.ipynb
+++ b/nbcelltests/tests/_cell_counting.ipynb
@@ -4,14 +4,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "tests": [
-     "assert x == 1"
-    ]
+    "tests": []
    },
    "outputs": [],
-   "source": [
-    "x = 1"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/nbcelltests/tests/_cell_not_injected_or_mocked.ipynb
+++ b/nbcelltests/tests/_cell_not_injected_or_mocked.ipynb
@@ -3,86 +3,62 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# nothing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "def f(x): return x\n",
-    "class X: pass"
-   ],   
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "metadata": {
     "tests": [
-     "%cell\n",
-     "def f(x): return x"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "def f(x): return x\n",
-    "f(1)\n",
-    "f(2)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "source": [
-    "class X: pass\n",
-    "%magics3"
-   ],   
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "tests": [
-     "x = 4\n",
-     "assert x == 4\n",
-     "%dirs\n",
      "# no %cell"
     ]
    },
    "outputs": [],
    "source": [
-    "x = 3"
+     "x = 1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# nothing to see here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 1"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "tests": []
-   },
+    "tests": [
+     "%cell"
+    ]
+   },   
    "outputs": [],
    "source": [
-    "x = 4"
+    "x = 1"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tests": [
+     "x = 17"
+    ]
+   },
    "outputs": [],
    "source": [
-    "%dirs\n",
-    "class X: pass"
+    "x = 1"
    ]
-  }      
+  }
  ],
  "metadata": {
-  "celltests": {
-   "cell_coverage": 50
-  }, 
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/nbcelltests/tests/_cumulative_run.ipynb
+++ b/nbcelltests/tests/_cumulative_run.ipynb
@@ -5,7 +5,7 @@
    "execution_count": 1,
    "metadata": {
     "tests": [
-     "pass"
+     "# no %cell"
     ]
    },
    "outputs": [],
@@ -68,7 +68,46 @@
    "source": [
     "pass"
    ]
-  }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tests": [
+     "\n"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "y = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tests": [
+     "# no %cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "a = 1"
+   ]
+  },  
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tests": [
+     "%cell\n"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "z = 1"
+   ]
+  }    
  ],
  "metadata": {
   "kernelspec": {

--- a/nbcelltests/tests/_empty_cell_with_test.ipynb
+++ b/nbcelltests/tests/_empty_cell_with_test.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,   
+   "source": [],
+   "outputs": [],   
+   "metadata": {
+    "tests": [
+     "# empty test"
+    ]
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,   
+   "source": [],
+   "outputs": [],   
+   "metadata": {
+    "tests": [
+     "pass # not empty test"
+    ]
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7.6 64-bit ('celltestsui': conda)",
+   "language": "python",
+   "name": "python37664bitcelltestsuiconda549e14be7f784a2fbde278c18c8be829"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_emptyast_cell_with_test.ipynb
+++ b/nbcelltests/tests/_emptyast_cell_with_test.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,   
+   "source": [],
+   "outputs": [],   
+   "metadata": {
+    "tests": [
+     "# empty test"
+    ]
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,   
+   "source": [
+    "# nothing to see here"
+   ],
+   "outputs": [],   
+   "metadata": {
+    "tests": [
+     "pass # not empty test"
+    ]
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7.6 64-bit ('celltestsui': conda)",
+   "language": "python",
+   "name": "python37664bitcelltestsuiconda549e14be7f784a2fbde278c18c8be829"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbcelltests/tests/_skips.ipynb
+++ b/nbcelltests/tests/_skips.ipynb
@@ -5,7 +5,7 @@
    "execution_count": 1,
    "metadata": {
     "tests": [
-     "pass"
+     "\n"
     ]
    },
    "outputs": [],
@@ -26,44 +26,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = 1"
+    "x = 3"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "tests": [
-     "# nothing to see here"
-    ]
+    "tests": []
    },   
    "outputs": [],
    "source": [
-    "x = 1"
+    "x = 4"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "tests": []
-   },   
-   "outputs": [],
-   "source": [
-    "x = 1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
     "tests": [
-     "x = 2"
+     "# no %cell\n",
+     "x = 6"
     ]
    },
    "outputs": [],
    "source": [
-    "x = 1"
+    "x = 5"
    ]
   }
  ],

--- a/nbcelltests/tests/test_shared.py
+++ b/nbcelltests/tests/test_shared.py
@@ -10,7 +10,7 @@ import os
 import pytest
 import nbformat
 
-from nbcelltests.shared import extract_extrametadata, get_coverage, is_empty
+from nbcelltests.shared import extract_extrametadata, get_coverage, empty_ast, only_whitespace
 
 # TODO: should generate these
 BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
@@ -19,14 +19,51 @@ MAGICS_NB = os.path.join(os.path.dirname(__file__), 'magics.ipynb')
 COVERAGE_NB = os.path.join(os.path.dirname(__file__), '_cell_coverage.ipynb')
 LINT_DISABLE_NB = os.path.join(os.path.dirname(__file__), '_lint_disable.ipynb')
 
+# TODO should parameterize test_empty_ast _whitespace
 
-def test_is_empty():
-    assert is_empty("import blah\nblah.do_something()") is False
-    assert is_empty("%matplotlib inline") is False
-    assert is_empty("pass") is False
-    assert is_empty("") is True
-    assert is_empty("#pass") is True
-    assert is_empty("\n\n\n") is True
+# empty ast, empty whitespace
+_empty_empty = [
+    "",
+    " ",
+    "\t",
+    "\n",
+    "\r\n"
+]
+
+# empty ast, non-empty whitespace
+_empty_nonempty = [
+    "#pass",
+]
+
+
+# non-empty ast, non-empty whitespace
+_nonempty_nonempty = [
+    "import blah\nblah.do_something()",
+    "%matplotlib inline",
+    "pass"
+]
+
+
+def test_empty_ast():
+    for x in _empty_empty:
+        assert empty_ast(x) is True
+
+    for x in _empty_nonempty:
+        assert empty_ast(x) is True
+
+    for x in _nonempty_nonempty:
+        assert empty_ast(x) is False
+
+
+def test_only_whitespace():
+    for x in _empty_empty:
+        assert only_whitespace(x) is True
+
+    for x in _empty_nonempty:
+        assert only_whitespace(x) is False
+
+    for x in _nonempty_nonempty:
+        assert only_whitespace(x) is False
 
 
 def _metadata(nb, what):
@@ -92,7 +129,7 @@ def test_extract_extrametadata_cell_lines_noncode():
 
 
 def test_extract_extrametadata_magics_noncode():
-    assert _metadata(COVERAGE_NB, 'magics') == set(['magics2'])
+    assert _metadata(COVERAGE_NB, 'magics') == set(['dirs'])
 
 
 # coverage

--- a/nbcelltests/tests/test_shared.py
+++ b/nbcelltests/tests/test_shared.py
@@ -207,16 +207,16 @@ def test_extract_extrametadata_disable_bad_regex():
 
 @pytest.mark.parametrize(
     "test_line, expected", [
-        (r"%cell", (0,5)),
-        (r"%cell;x", (0,5)),
+        (r"%cell", (0, 5)),
+        (r"%cell;x", (0, 5)),
         pytest.param(r"%celll", None, marks=pytest.mark.xfail(reason="need to decide rules/really treat as token")),
         (r"", None),
-        (r"    %cell", (4,9)),
+        (r"    %cell", (4, 9)),
         (r"# no %cell", None),
         (r"# %cell", None)
     ]
 )
-def test_get_cell_inj_span(test_line,expected):
+def test_get_cell_inj_span(test_line, expected):
     assert get_cell_inj_span(test_line) == expected
 
 
@@ -277,8 +277,8 @@ if x==1:
 %cell
 # no %cell
 """, NotImplemented, (ValueError, "mutually exclusive")),
-])
-def test_cell_injected_into_test(test_source,expected,exception):
+    ])
+def test_cell_injected_into_test(test_source, expected, exception):
     if exception is None:
         assert cell_injected_into_test(test_source) is expected
     else:

--- a/nbcelltests/tests/test_shared.py
+++ b/nbcelltests/tests/test_shared.py
@@ -10,7 +10,7 @@ import os
 import pytest
 import nbformat
 
-from nbcelltests.shared import extract_extrametadata, get_coverage, empty_ast, only_whitespace
+from nbcelltests.shared import extract_extrametadata, get_coverage, empty_ast, only_whitespace, cell_injected_into_test, get_cell_inj_span
 
 # TODO: should generate these
 BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
@@ -203,3 +203,84 @@ def test_extract_extrametadata_disable_bad_regex():
         assert e.args[0] == "noqa_regex must contain one capture group (specifying the rule)"
     else:
         assert False, "should have raised a ValueError"
+
+
+@pytest.mark.parametrize(
+    "test_line, expected", [
+        (r"%cell", (0,5)),
+        (r"%cell;x", (0,5)),
+        pytest.param(r"%celll", None, marks=pytest.mark.xfail(reason="need to decide rules/really treat as token")),
+        (r"", None),
+        (r"    %cell", (4,9)),
+        (r"# no %cell", None),
+        (r"# %cell", None)
+    ]
+)
+def test_get_cell_inj_span(test_line,expected):
+    assert get_cell_inj_span(test_line) == expected
+
+
+# TODO could clean up with textwrap dedent etc
+@pytest.mark.parametrize(
+    "test_source, expected, exception", [
+        (r"""\
+%cell
+""", True, None),
+
+        (r"""\
+%cell
+%cell
+""", True, None),
+
+        (r"""\
+%cell;x
+""", True, None),
+
+        pytest.param(r"""\
+%celll
+""", None, None, marks=pytest.mark.xfail(reason="need to decide rules/really treat as token")),
+
+        (r"""\
+""", None, None),
+
+        (r"""\
+%cell l
+""", True, None),
+
+        (r"""\
+x = 1
+%cell
+""", True, None),
+
+        (r"""\
+x = 1
+if x==1:
+    %cell
+""", True, None),
+
+        (r"""\
+# no %cell
+""", False, None),
+
+        (r"""\
+x = 1
+if x==1:
+    pass
+    # no %cell
+""", False, None),
+
+        (r"""\
+%cell # no %cell
+""", True, None),
+
+        (r"""\
+%cell
+# no %cell
+""", NotImplemented, (ValueError, "mutually exclusive")),
+])
+def test_cell_injected_into_test(test_source,expected,exception):
+    if exception is None:
+        assert cell_injected_into_test(test_source) is expected
+    else:
+        with pytest.raises(exception[0], match=exception[1]):
+            cell_injected_into_test(test_source)

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -33,6 +33,7 @@ TEST_FAIL = os.path.join(os.path.dirname(__file__), '_test_fail.ipynb')
 COUNTING = os.path.join(os.path.dirname(__file__), '_cell_counting.ipynb')
 NONCODE = os.path.join(os.path.dirname(__file__), '_non_code_cell.ipynb')
 EMPTY_CELL_WITH_TEST = os.path.join(os.path.dirname(__file__), '_empty_cell_with_test.ipynb')
+EMPTYAST_CELL_WITH_TEST = os.path.join(os.path.dirname(__file__), '_emptyast_cell_with_test.ipynb')
 SKIPS = os.path.join(os.path.dirname(__file__), '_skips.ipynb')
 COVERAGE = os.path.join(os.path.dirname(__file__), '_cell_coverage.ipynb')
 CELL_NOT_INJECTED_OR_MOCKED = os.path.join(os.path.dirname(__file__), '_cell_not_injected_or_mocked.ipynb')
@@ -130,9 +131,17 @@ class TestMethodGenerationError(_TestCellTests):
         else:
             raise Exception("Test script should fail to generate")
 
-    def test_non_code_cell_with_test_causes_error(self):
+    def test_onlywhitespace_code_cell_with_test_causes_error(self):
         try:
             _generate_test_module(EMPTY_CELL_WITH_TEST, "module.name.irrelevant")
+        except ValueError as e:
+            assert e.args[0] == 'Code cell 2 is empty, but test contains code.'
+        else:
+            raise Exception("Test script should fail to generate")
+
+    def test_emptyast_code_cell_with_test_causes_error(self):
+        try:
+            _generate_test_module(EMPTYAST_CELL_WITH_TEST, "module.name.irrelevant")
         except ValueError as e:
             assert e.args[0] == 'Code cell 2 is empty, but test contains code.'
         else:

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -11,6 +11,8 @@ import os
 import sys
 import unittest
 
+import pytest
+
 from nbcelltests.test import run, runWithReturn, runWithReport, runWithHTMLReturn
 
 # Some straightforward TODOs:
@@ -431,11 +433,12 @@ class TestFailureInTest(_TestCellTests):
         t.tearDownClass()
 
 
-# TODO: this is an nbval bug
+# TODO: see https://github.com/computationalmodelling/nbval/issues/147
 class TestSomeSanity(_TestCellTests):
 
     NBNAME = BROKEN_MAGICS
 
+    @pytest.mark.xfail(reason="error messages on shell channel are ignored by nbval")
     def test_bad_magic_does_let_everything_pass(self):
         t = self.generated_tests.TestNotebook()
 

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -329,9 +329,6 @@ class TestNotebookBase(unittest.TestCase):
             elif msg_type in ('display_data', 'execute_result'):
                 continue
             elif msg_type == 'stream':
-                # TODO: temporary/should not be here; needs fix in nbval
-                if msg['content']['name'] == 'stderr':
-                    raise Exception(msg['content']['text'])
                 continue
 
             # if the message type is an error then an error has occurred during

--- a/nbcelltests/tests_vendored.py
+++ b/nbcelltests/tests_vendored.py
@@ -143,7 +143,7 @@ def get_celltests(path_to_notebook):
 
         code_cell += 1
 
-        if empty_ast(cell['source']): # TODO: maybe this should be only_whitespace?
+        if empty_ast(cell['source']):  # TODO: maybe this should be only_whitespace?
             if not test_ast_empty:
                 raise ValueError("Code cell %d is empty, but test contains code." % code_cell)
             continue


### PR DESCRIPTION
Fixes #169, i.e. implements what is described in the opening comment there.

The important changes are in nbcelltets.tests_vendored - the rest is test updates.

Questions:
  * Decide what magic comment to use for saying "cell is mocked" (i.e. do not run this cell). Currently `# no %cell`. Vidar proposed `# nbcelltest-skip`. Or even possibly go straight to #171? (I'd rather try the current underlying behavior out for a bit, then if we are keeping it, use a better mechanism than comment.)
  * Agree it's ok to generate and run a `test_cell_3` method (as opposed to not generating/skipping) when no explicit test has been supplied for cell 3, and hence the test defaults to `%cell`. (This is "case 3 from #169.) I think we need some people to try it out in lab etc and give feedback one way or the other.
  * In this PR, a code cell that has an empty ast cannot have a test (exception if it does have a test). Does that seem ok? E.g. would it be reasonable to write `# note: there is a test at this cell!` in your notebook, and have test code? 

To do:
  * [x] Validate implementation matches #169 
  * [x] Validate it seems to makes sense when using in lab (at least to author!)
  * [x] ~~Upstream equivalent nbval fix for bad magics (not how it's done here)~~ filed an issue/started a PR/it's not related to this PR


Also:
  * Default text in lab's CELLTESTS changed (more instruction, reflects default)
  * Distinguish "only whitespace" from "empty ast" more clearly (previously, "is empty" was "empty ast"). This PR does not change the fact that "empty cell" is "empty ast".
  * Closes #117 (no skips now anyway)
  * Added tests showing #173 (known fail for now)