### PR TITLE
Upgrade pip before building packages.

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -42,6 +42,7 @@ stages:
       inputs:
         versionSpec: '12.x'
     - script: |
+        python -m pip install --upgrade pip
         # duplicates pyproject.toml; see https://github.com/pypa/pip/issues/6041 etc etc etc...
         python -m pip install wheel setuptools jupyter-packaging twine
         make dist

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0, 2, 1, 'alpha', 0
+current_version = 0, 2, 1, 'alpha', 1
 commit = True
 tag = False
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_celltests",
-  "version": "0.2.1-alpha.0",
+  "version": "0.2.1-alpha.1",
   "description": "A JupyterLab extension for cell-by-cell testing and linting of notebooks.",
   "author": "The nbcelltests authors",
   "main": "lib/index.js",

--- a/nbcelltests/_version.py
+++ b/nbcelltests/_version.py
@@ -12,7 +12,7 @@ VersionInfo = namedtuple('VersionInfo', [
 ])
 
 # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
-version_info = VersionInfo(0, 2, 1, 'alpha', 0)
+version_info = VersionInfo(0, 2, 1, 'alpha', 1)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 


### PR DESCRIPTION
Whatever older version of pip is part of azure's python distribution does include pyproject.toml in sdist.