### PR TITLE
Support nbcelltests.lint on python 2

### DIFF
--- a/.azure/dev-template.yml
+++ b/.azure/dev-template.yml
@@ -44,6 +44,7 @@ jobs:
   - script:
       make verify-install
     displayName: 'Check everything was installed'
+    condition: not(in(variables['python.version'], '2.7'))
 
   - script: |
       make lint

--- a/.azure/dev-template.yml
+++ b/.azure/dev-template.yml
@@ -9,6 +9,8 @@ jobs:
 
   strategy:
     matrix:
+      Python27:
+        python.version: '2.7'
       Python36:
         python.version: '3.6'
       Python37:

--- a/nbcelltests/extension.py
+++ b/nbcelltests/extension.py
@@ -16,9 +16,9 @@ from concurrent.futures import ThreadPoolExecutor
 from notebook.base.handlers import IPythonHandler
 from notebook.utils import url_path_join
 try:
-    from backports.tempfile import TemporaryDirectory
-except ImportError:
     from tempfile import TemporaryDirectory
+except ImportError:
+    from backports.tempfile import TemporaryDirectory
 
 from .test import runWithHTMLReturn as runTest
 from .lint import runWithHTMLReturn as runLint

--- a/nbcelltests/lint.py
+++ b/nbcelltests/lint.py
@@ -103,7 +103,8 @@ def run(notebook, executable=None, rules=None, noqa_regex=None):
     extra_metadata.update(rules)
 
     # TODO: consider warning if referring to non-existent rules
-    rules_to_remove = extra_metadata['noqa'] & extra_metadata.keys()
+    # set() is for python 2; remove when py2 is fully dropped
+    rules_to_remove = extra_metadata['noqa'] & set(extra_metadata.keys())
     for rule in rules_to_remove:
         del extra_metadata[rule]
 

--- a/nbcelltests/shared.py
+++ b/nbcelltests/shared.py
@@ -191,7 +191,7 @@ CELL_SKIP_TOKEN = r"# no %cell"
 
 
 def source2lines(source):
-    return source.splitlines(keepends=True)
+    return source.splitlines(True)
 
 
 def lines2source(lines):

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -33,7 +33,7 @@ from nbcelltests.test import run, runWithReturn, runWithReport, runWithHTMLRetur
 
 # TODO: This test file's manual use of unittest is brittle
 
-pytestmark = pytest.mark.skipif(sys.version_info.major<3, reason="python 3 required")
+pytestmark = pytest.mark.skipif(sys.version_info.major < 3, reason="python 3 required")
 
 CUMULATIVE_RUN = os.path.join(os.path.dirname(__file__), '_cumulative_run.ipynb')
 CELL_ERROR = os.path.join(os.path.dirname(__file__), '_cell_error.ipynb')

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -33,6 +33,8 @@ from nbcelltests.test import run, runWithReturn, runWithReport, runWithHTMLRetur
 
 # TODO: This test file's manual use of unittest is brittle
 
+pytestmark = pytest.mark.skipif(sys.version_info.major<3, reason="python 3 required")
+
 CUMULATIVE_RUN = os.path.join(os.path.dirname(__file__), '_cumulative_run.ipynb')
 CELL_ERROR = os.path.join(os.path.dirname(__file__), '_cell_error.ipynb')
 TEST_ERROR = os.path.join(os.path.dirname(__file__), '_test_error.ipynb')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "jupyter-packaging"]
+requires = [
+  "setuptools",
+  "wheel",
+  "jupyter-packaging <0.5 ; python_version <'3'",
+  "jupyter-packaging ; python_version >='3'",  
+]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ requires = [
     'pytest-html>=1.20.0',
     'flake8',
     'parameterized',
+    'backports.tempfile ; python_version < "3"'
 ]
 
 dev_requires = requires + [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 requires = [
-    'jupyterlab>=1.0.0',
+    'jupyterlab>=1.0.0 ; python_version > "3"',
+    'jupyterlab ; python_version < "3"',
     'nbval>=0.9.1',
     'nbconvert',
     'pytest>=4.4.0',


### PR DESCRIPTION
* Allow someone to use nbcelltests.lint on python 2.
* Enable installation without manual modification on python 2.
* Add python 2 to CI matrix (but don't run all parts of CI with python 2).