### PR TITLE
Correcting runWithHTMLReturn2() Function in test.py

### DIFF
--- a/nbcelltests/test.py
+++ b/nbcelltests/test.py
@@ -129,11 +129,11 @@ def runWithHTMLReturn2(notebook, executable=None, **run_kw):
     '''use custom return objects'''
     ret = ''
     executable = executable or [sys.executable, '-m', 'pytest', '-v']
-    ret_tmp = run(notebook, **run_kw)
+    ret_tmp = runWithReport(notebook, **run_kw)
     for test in ret_tmp:
         test = test.to_html()
         ret += '<p>' + test + '</p>'
-    return '<div style="display: flex; flex-direction: column;">' + test + '</div>'
+    return '<div style="display: flex; flex-direction: column;">' + ret + '</div>'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Initially, runWithHTMLReturn2() function was iterating over the name of test script received from the run() function but to get the report in defined format of define.py TestMessage class it should iterate over list of TestMessage received from runWithReport() function and it was finally returning single test but it should return ret variable containing all tests.