### PR TITLE
Replaced --forked in internal tests

### DIFF
--- a/.azure/dev-template.yml
+++ b/.azure/dev-template.yml
@@ -54,7 +54,7 @@ jobs:
 
     - script:
         make testpy-forked
-      displayName: 'pytest --forked'
+      displayName: 'pytest -n 2'
 
   - script:
       make tests

--- a/.azure/dev-template.yml
+++ b/.azure/dev-template.yml
@@ -53,8 +53,8 @@ jobs:
   - ${{ if eq(parameters.also_forked, 'true') }}:
 
     - script:
-        make testpy-forked
-      displayName: 'pytest -n 2'
+        make testpy-distributed
+      displayName: 'pytest distributed'
 
   - script:
       make tests

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ testjs: ## Clean and Make js tests
 testpy: ## Clean and Make unit tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests
 
-testpy-forked: ## Python unit tests parallelized across two CPUs
+testpy-distributed: ## Python unit tests parallelized across two CPUs
 	${PYTHON} -m pytest -v -n 2 --dist=loadscope nbcelltests/tests
 
 tests: lint ## run the tests

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ testpy: ## Clean and Make unit tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests
 
 testpy-forked: ## Python unit tests parallelized across two CPUs
-	${PYTHON} -m pytest -v -n 2 nbcelltests/tests
+	${PYTHON} -m pytest -v -n 2 --dist=loadscope nbcelltests/tests
 
 tests: lint ## run the tests
 	rm -rf nbcelltests/tests/_*_test.py

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ testpy: ## Clean and Make unit tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests
 
 testpy-distributed: ## Python unit tests parallelized across two CPUs
+# --dist=loadscope causes tests in the same class to be run sequentially
+# This is useful when we want to prevent certain tests from running simultaneously.
 	${PYTHON} -m pytest -v -n 2 --dist=loadscope nbcelltests/tests
 
 tests: lint ## run the tests

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ testpy: ## Clean and Make unit tests
 
 testpy-distributed: ## Python unit tests parallelized across two CPUs
 # --dist=loadscope causes tests in the same class to be run sequentially
-# This is useful when we want to prevent certain tests from running simultaneously.
+# Required until https://github.com/jpmorganchase/nbcelltests/issues/207 is addressed
 	${PYTHON} -m pytest -v -n 2 --dist=loadscope nbcelltests/tests
 
 tests: lint ## run the tests

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ testjs: ## Clean and Make js tests
 testpy: ## Clean and Make unit tests
 	${PYTHON} -m pytest -v nbcelltests/tests --cov=nbcelltests
 
-testpy-forked: ## Python unit tests --forked (not windows!)
-	${PYTHON} -m pytest -v --forked nbcelltests/tests
+testpy-forked: ## Python unit tests parallelized across two CPUs
+	${PYTHON} -m pytest -v -n 2 nbcelltests/tests
 
 tests: lint ## run the tests
 	rm -rf nbcelltests/tests/_*_test.py

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -56,9 +56,6 @@ INPUT_CELL_NEWLINE_STRING = os.path.join(os.path.dirname(__file__), '_input_cell
 INPUT_TEST_NEWLINE_STRING = os.path.join(os.path.dirname(__file__), '_input_test_newline_string.ipynb')
 INPUT_TEST_INJECTION_COMMENT = os.path.join(os.path.dirname(__file__), '_input_test_injection_comment.ipynb')
 
-# Hack. We want to test expected behavior in distributed situation,
-# which we are doing via pytest --forked.
-FORKED = '--forked' in sys.argv
 
 # Default to using kernel from current environment (like --current-env of nbval).
 TEST_RUN_KW = {
@@ -285,84 +282,56 @@ class TestCumulativeRun(_TestCellTests):
         t.test_code_cell_1()
         _assert_undefined(t, 'x')
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # check cell ran
         # (%cell in test)
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_2()
         t._run("""
         assert x == 0, x
         """)
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # check cumulative cells ran
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_3()
         t._run("""
         assert x == 1, x
         """)
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # check cumulative cells ran (but not multiple times!)
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_4()
         t._run("""
         assert x == 2, x
         """)
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # check test affects state
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_5()
         t._run("""
         assert x == 3, x
         """)
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # test defaults to %cell
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_6()
         t._run("""
         assert y == 10
         """)
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # deliberate no %cell; cell 8 will check it's also not subsequently run
         # i.e. a will never be defined
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_7()
         _assert_undefined(t, 'a')
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
 
         # check cell 7 above did not run
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         t.test_code_cell_8()
         t._run("""
@@ -413,11 +382,6 @@ class TestExceptionInTest(_TestCellTests):
         t.test_code_cell_1()
 
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
-
-        if FORKED:
-            t.setUpClass()
         t.setUp()
 
         _assert_undefined(t, 'x')
@@ -455,11 +419,6 @@ class TestFailureInTest(_TestCellTests):
             raise Exception("Test should have failed")
 
         t.tearDown()
-        if FORKED:
-            t.tearDownClass()
-
-        if FORKED:
-            t.setUpClass()
         t.setUp()
         # subsequent cell should also fail
         try:

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -722,117 +722,119 @@ def test_kernel_selection(notebook, current_env, kernel_name, exception, expecte
 # https://github.com/jpmorganchase/nbcelltests/issues/125 before
 # deciding how to handle that better here.
 
-# runWithReturn
+class TestConverage:
 
-def test_basic_runWithReturn_pass():
-    """Basic check - just that it runs without error"""
-    generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
-    if os.path.exists(generates):
-        raise ValueError("Going to generate %s but it already exists." % generates)
+    # runWithReturn
 
-    try:
-        _ = run(COVERAGE, rules={'cell_coverage': 10}, **TEST_RUN_KW)
-    finally:
+    def test_basic_runWithReturn_pass(self):
+        """Basic check - just that it runs without error"""
+        generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
+        if os.path.exists(generates):
+            raise ValueError("Going to generate %s but it already exists." % generates)
+
         try:
-            os.remove(generates)
+            _ = run(COVERAGE, rules={'cell_coverage': 10}, **TEST_RUN_KW)
+        finally:
+            try:
+                os.remove(generates)
+            except Exception:
+                pass
+
+
+    def test_basic_runWithReturn_fail(self):
+        """Basic check - just that it fails"""
+        generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
+        if os.path.exists(generates):
+            raise ValueError("Going to generate %s but it already exists." % generates)
+
+        try:
+            _ = run(COVERAGE, rules={'cell_coverage': 100}, **TEST_RUN_KW)
         except Exception:
-            pass
+            pass  # would need to alter run fn or capture output to check more exactly
+        else:
+            raise ValueError("coverage check should have failed, but didn't")
+        finally:
+            try:
+                os.remove(generates)
+            except Exception:
+                pass
 
 
-def test_basic_runWithReturn_fail():
-    """Basic check - just that it fails"""
-    generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
-    if os.path.exists(generates):
-        raise ValueError("Going to generate %s but it already exists." % generates)
+    # runWithReport
 
-    try:
-        _ = run(COVERAGE, rules={'cell_coverage': 100}, **TEST_RUN_KW)
-    except Exception:
-        pass  # would need to alter run fn or capture output to check more exactly
-    else:
-        raise ValueError("coverage check should have failed, but didn't")
-    finally:
+    def test_basic_runWithReport_pass(self):
+        """Basic check - just that it runs without error"""
+        generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
+        if os.path.exists(generates):
+            raise ValueError("Going to generate %s but it already exists." % generates)
+
+        from nbcelltests.define import TestType
         try:
-            os.remove(generates)
-        except Exception:
-            pass
+            ret = runWithReport(COVERAGE, executable=None, rules={'cell_coverage': 10}, **TEST_RUN_KW)
+        finally:
+            try:
+                os.remove(generates)
+            except Exception:
+                pass
+
+        assert len(ret) == 1
+        assert (ret[0].passed, ret[0].type, ret[0].message) == (1, TestType.CELL_COVERAGE, 'Testing cell coverage')
 
 
-# runWithReport
+    # def test_basic_runWithReport_fail():
+    #    from nbcelltests.define import TestType
+    #    # TODO it fails here, but it shouldn't, right? we want to be able to report
+    #    ret = runWithReport(COVERAGE, executable=None, rules={'cell_coverage':100})
+    #    assert len(ret) == 1
+    #    assert (ret[0].passed, ret[0].type, ret[0].message) == (False, TestType.CELL_COVERAGE, 'Testing cell coverage')
 
-def test_basic_runWithReport_pass():
-    """Basic check - just that it runs without error"""
-    generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
-    if os.path.exists(generates):
-        raise ValueError("Going to generate %s but it already exists." % generates)
 
-    from nbcelltests.define import TestType
-    try:
-        ret = runWithReport(COVERAGE, executable=None, rules={'cell_coverage': 10}, **TEST_RUN_KW)
-    finally:
+    # runWithHTMLReturn
+
+    def test_basic_runWithHTMLReturn_pass(self):
+        """Check it runs without error and generates the expected files and html."""
+        generates = [os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py"),
+                    os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
+        exists_check = [os.path.exists(f) for f in generates]
+        if any(exists_check):
+            raise ValueError("Going to generate %s but already exist(s)" % [f for f, exists in zip(generates, exists_check) if exists])
+
         try:
-            os.remove(generates)
-        except Exception:
-            pass
+            ret = run(COVERAGE, html=True, executable=None, rules={'cell_coverage': 10}, **TEST_RUN_KW)
 
-    assert len(ret) == 1
-    assert (ret[0].passed, ret[0].type, ret[0].message) == (1, TestType.CELL_COVERAGE, 'Testing cell coverage')
-
-
-# def test_basic_runWithReport_fail():
-#    from nbcelltests.define import TestType
-#    # TODO it fails here, but it shouldn't, right? we want to be able to report
-#    ret = runWithReport(COVERAGE, executable=None, rules={'cell_coverage':100})
-#    assert len(ret) == 1
-#    assert (ret[0].passed, ret[0].type, ret[0].message) == (False, TestType.CELL_COVERAGE, 'Testing cell coverage')
-
-
-# runWithHTMLReturn
-
-def test_basic_runWithHTMLReturn_pass():
-    """Check it runs without error and generates the expected files and html."""
-    generates = [os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py"),
-                 os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
-    exists_check = [os.path.exists(f) for f in generates]
-    if any(exists_check):
-        raise ValueError("Going to generate %s but already exist(s)" % [f for f, exists in zip(generates, exists_check) if exists])
-
-    try:
-        ret = run(COVERAGE, html=True, executable=None, rules={'cell_coverage': 10}, **TEST_RUN_KW)
-
-        for f in generates:
-            assert os.path.exists(f), "Should have generated %s but did not" % f
-    finally:
-        try:
             for f in generates:
-                os.remove(f)
-        except Exception:
-            pass
+                assert os.path.exists(f), "Should have generated %s but did not" % f
+        finally:
+            try:
+                for f in generates:
+                    os.remove(f)
+            except Exception:
+                pass
 
-    _check(ret, coverage_result="Passed")
+        _check(ret, coverage_result="Passed")
 
 
-def test_basic_runWithHTMLReturn_fail():
-    """Check it runs without error and generates the expected files and html."""
-    generates = [os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py"),
-                 os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
-    exists_check = [os.path.exists(f) for f in generates]
-    if any(exists_check):
-        raise ValueError("Going to generate %s but already exist(s)" % [f for f, exists in zip(generates, exists_check) if exists])
+    def test_basic_runWithHTMLReturn_fail(self):
+        """Check it runs without error and generates the expected files and html."""
+        generates = [os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py"),
+                    os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
+        exists_check = [os.path.exists(f) for f in generates]
+        if any(exists_check):
+            raise ValueError("Going to generate %s but already exist(s)" % [f for f, exists in zip(generates, exists_check) if exists])
 
-    try:
-        ret = run(COVERAGE, html=True, executable=None, rules={'cell_coverage': 100}, **TEST_RUN_KW)
-
-        for f in generates:
-            assert os.path.exists(f), "Should have generated %s but did not" % f
-    finally:
         try:
-            for f in generates:
-                os.remove(f)
-        except Exception:
-            pass
+            ret = run(COVERAGE, html=True, executable=None, rules={'cell_coverage': 100}, **TEST_RUN_KW)
 
-    _check(ret, coverage_result="Failed")
+            for f in generates:
+                assert os.path.exists(f), "Should have generated %s but did not" % f
+        finally:
+            try:
+                for f in generates:
+                    os.remove(f)
+            except Exception:
+                pass
+
+        _check(ret, coverage_result="Failed")
 
 
 def _check(html, coverage_result):

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -681,6 +681,9 @@ def test_kernel_selection(notebook, current_env, kernel_name, exception, expecte
 # https://github.com/jpmorganchase/nbcelltests/issues/125 before
 # deciding how to handle that better here.
 
+# All the tests in this class work on the same files and require that
+# those files do not already exist. Placing these tests in the same
+# class prevents them from running simultaneously.
 class TestCoverage:
 
     # runWithReturn

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -681,9 +681,8 @@ def test_kernel_selection(notebook, current_env, kernel_name, exception, expecte
 # https://github.com/jpmorganchase/nbcelltests/issues/125 before
 # deciding how to handle that better here.
 
-# All the tests in this class work on the same files and require that
-# those files do not already exist. Placing these tests in the same
-# class prevents them from running simultaneously.
+# No need to group these tests in a class (to be run sequentially) once
+# https://github.com/jpmorganchase/nbcelltests/issues/207 is resolved.
 class TestCoverage:
 
     # runWithReturn

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -681,7 +681,7 @@ def test_kernel_selection(notebook, current_env, kernel_name, exception, expecte
 # https://github.com/jpmorganchase/nbcelltests/issues/125 before
 # deciding how to handle that better here.
 
-class TestConverage:
+class TestCoverage:
 
     # runWithReturn
 

--- a/nbcelltests/tests/test_test.py
+++ b/nbcelltests/tests/test_test.py
@@ -699,7 +699,6 @@ class TestCoverage:
             except Exception:
                 pass
 
-
     def test_basic_runWithReturn_fail(self):
         """Basic check - just that it fails"""
         generates = os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py")
@@ -717,7 +716,6 @@ class TestCoverage:
                 os.remove(generates)
             except Exception:
                 pass
-
 
     # runWithReport
 
@@ -739,7 +737,6 @@ class TestCoverage:
         assert len(ret) == 1
         assert (ret[0].passed, ret[0].type, ret[0].message) == (1, TestType.CELL_COVERAGE, 'Testing cell coverage')
 
-
     # def test_basic_runWithReport_fail():
     #    from nbcelltests.define import TestType
     #    # TODO it fails here, but it shouldn't, right? we want to be able to report
@@ -747,13 +744,12 @@ class TestCoverage:
     #    assert len(ret) == 1
     #    assert (ret[0].passed, ret[0].type, ret[0].message) == (False, TestType.CELL_COVERAGE, 'Testing cell coverage')
 
-
     # runWithHTMLReturn
 
     def test_basic_runWithHTMLReturn_pass(self):
         """Check it runs without error and generates the expected files and html."""
         generates = [os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py"),
-                    os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
+                     os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
         exists_check = [os.path.exists(f) for f in generates]
         if any(exists_check):
             raise ValueError("Going to generate %s but already exist(s)" % [f for f, exists in zip(generates, exists_check) if exists])
@@ -772,11 +768,10 @@ class TestCoverage:
 
         _check(ret, coverage_result="Passed")
 
-
     def test_basic_runWithHTMLReturn_fail(self):
         """Check it runs without error and generates the expected files and html."""
         generates = [os.path.join(os.path.dirname(__file__), "__cell_coverage_test.py"),
-                    os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
+                     os.path.join(os.path.dirname(__file__), "__cell_coverage_test.html")]
         exists_check = [os.path.exists(f) for f in generates]
         if any(exists_check):
             raise ValueError("Going to generate %s but already exist(s)" % [f for f, exists in zip(generates, exists_check) if exists])

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requires = requires + [
     'jupyterlab>=1.0.0 ; python_version > "3"',
     'jupyterlab ; python_version < "3"',
     'mock',
-    'pytest-xdist ; sys_platform != "win32"',
+    'pytest-xdist',
 ]
 
 data_spec = [


### PR DESCRIPTION
Resolves #107:

- `pytest-xdist` will now be installed on Windows
- Replaced `--forked` with `-n 2`
- Tests like `test_basic_runWithReturn_pass` and 4 others do not want to have the file `__cell_coverage_test.py` already created. I grouped all these 5 tests under a class `TestCoverage` so that these tests are run sequentially by a worker spawn by `pytest-xdist`
- Removed special handling of `--forked`. Now, tests like `test_state` behave as if it's always `FORKED=False`.


Naming Choices:
- Would you want to rename `make pytest-forked` to something else?
- Azure test `pytest --forked` renames to `pytest -n 2`
- Is the class name `TestCoverage` apt for grouping these tests? `test_basic_runWithReturn_pass`, `test_basic_runWithReturn_fail`, `test_basic_runWithReport_pass`, `test_basic_runWithHTMLReturn_pass`, `test_basic_runWithHTMLReturn_fail`

It is not apparent looking at the diff of `test_test.py TestCoverage`, but I have only added those five tests to the class and I have not changed those tests.